### PR TITLE
fix(seo): SEO/GEO audit bundle — 10 findings + 2 self-discovered siblings

### DIFF
--- a/build-plugins/constants.ts
+++ b/build-plugins/constants.ts
@@ -705,6 +705,9 @@ export function countHtmlBodyWords(html: string): number {
 /** Minimum word count for a page to be considered indexable (not thin content). */
 export const MIN_INDEXABLE_WORDS = 50;
 
+/** Shared below-floor tag -- reused by both content-gated robots helpers below. */
+const ROBOTS_NOINDEX_FOLLOW = '\n <meta name="robots" content="noindex,follow">';
+
 /**
  * Returns the appropriate robots meta tag based on the word count of the page body.
  * Pages with >= MIN_INDEXABLE_WORDS get `index,follow`; below that, `noindex,follow`.
@@ -715,5 +718,29 @@ export function robotsMetaForContent(bodyHtml: string): string {
  if (wordCount >= MIN_INDEXABLE_WORDS) {
  return '\n <meta name="robots" content="index,follow">';
  }
- return '\n <meta name="robots" content="noindex,follow">';
+ return ROBOTS_NOINDEX_FOLLOW;
+}
+
+/**
+ * Enhanced robots directive for indexable pages, asking Google for large
+ * snippet/image/video previews in search results. Value matches what's
+ * already live on canton hub pages (e.g. /cerca-lavoro-ticino/) and used by
+ * staticPagesPlugin.ts / ogPagesPlugin.ts -- a single shared export so new
+ * callers reuse it instead of hand-typing the qualifier list.
+ */
+export const ROBOTS_INDEX_ENHANCED = '\n <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">';
+
+/**
+ * Same word-count gate as `robotsMetaForContent`, but returns the enhanced
+ * snippet/preview directives on the indexable branch instead of plain
+ * `index,follow`. For hub-style landing pages (sector/recency hubs) that
+ * aren't protected by an upstream inventory floor -- unlike the canton/city
+ * editorial hubs, which are always past a floor gate by the time they reach
+ * HTML emission and can use `ROBOTS_INDEX_ENHANCED` directly -- so content
+ * depth must be checked per-render instead of assumed.
+ */
+export function robotsMetaEnhancedForContent(bodyHtml: string): string {
+ return countHtmlBodyWords(bodyHtml) >= MIN_INDEXABLE_WORDS
+ ? ROBOTS_INDEX_ENHANCED
+ : ROBOTS_NOINDEX_FOLLOW;
 }

--- a/build-plugins/jobRecencyPagesPlugin.ts
+++ b/build-plugins/jobRecencyPagesPlugin.ts
@@ -18,6 +18,7 @@ import {
   GTAG_SNIPPET,
   ADSENSE_SNIPPET,
   CDN_PRECONNECT_HINT,
+  robotsMetaEnhancedForContent,
 } from './constants';
 import { asyncCssHeadBlock, rootShell } from './htmlTemplate';
 import {
@@ -281,6 +282,33 @@ export function jobRecencyPagesPlugin(rootDir: string): Plugin {
 
           const openAllHref = sectionRootUrl;
 
+          // Extracted (not inlined) so its text can feed the body word count
+          // below -- this accordion is what keeps low-inventory windows past
+          // the text-to-HTML ratio floor (see comment above proseHtml).
+          const commuterContextSummary = ({
+            it: 'Guida frontalieri: salario, permesso G, fisco, rientro',
+            en: 'Cross-border guide: salary, G permit, tax, weekly return',
+            de: 'Grenzgänger-Leitfaden: Lohn, G-Bewilligung, Steuer, Rückkehr',
+            fr: 'Guide frontaliers : salaire, permis G, fiscalité, retour',
+          } as Record<JobLandingLocale, string>)[locale];
+          const commuterContextInner = renderJobBoardCommuterContext({ locale, location: 'Ticino', omitCommute: true });
+          const commuterContextHtml = `<details class="hub-seo-context s-mxdIN0">
+          <summary class="s-1yn7b_">${commuterContextSummary}</summary>
+          <div class="s-yZU6bn">
+            <section class="s-p_RJwm">
+              ${commuterContextInner}
+            </section>
+          </div>
+        </details>`;
+
+          // No upstream inventory floor gates this page (unlike the
+          // canton/city editorial hubs in jobsSeoPagesPlugin.ts) -- every
+          // variant x locale combo emits regardless of job count, so the
+          // robots tag must be computed per-render from the actual assembled
+          // body content instead of assumed indexable.
+          const recencyBodyHtml = `${jobsHtml}${proseHtml}${faqHtml}${commuterContextHtml}`;
+          const recencyRobotsTag = robotsMetaEnhancedForContent(recencyBodyHtml);
+
           const html = `<!doctype html>
 <html lang="${locale}">
   <head>
@@ -288,7 +316,7 @@ export function jobRecencyPagesPlugin(rootDir: string): Plugin {
     <meta name="viewport" content="width=device-width,initial-scale=1">
     ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n    ` : ''}${FAVICON_LINKS}
     <title>${esc(model.title)}</title>
-    <meta name="description" content="${esc(clampMetaDescription(model.description))}">
+    <meta name="description" content="${esc(clampMetaDescription(model.description))}">${recencyRobotsTag}
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Frontaliere Ticino">
     <meta property="og:locale" content="${LOCALE_OG[locale]}">
@@ -348,23 +376,7 @@ ${alternates}
       </section>
       ${proseHtml}
       ${faqHtml}
-      ${(() => {
-        const summary = ({
-          it: 'Guida frontalieri: salario, permesso G, fisco, rientro',
-          en: 'Cross-border guide: salary, G permit, tax, weekly return',
-          de: 'Grenzgänger-Leitfaden: Lohn, G-Bewilligung, Steuer, Rückkehr',
-          fr: 'Guide frontaliers : salaire, permis G, fiscalité, retour',
-        } as Record<JobLandingLocale, string>)[locale];
-        const inner = renderJobBoardCommuterContext({ locale, location: 'Ticino', omitCommute: true });
-        return `<details class="hub-seo-context s-mxdIN0">
-          <summary class="s-1yn7b_">${summary}</summary>
-          <div class="s-yZU6bn">
-            <section class="s-p_RJwm">
-              ${inner}
-            </section>
-          </div>
-        </details>`;
-      })()}
+      ${commuterContextHtml}
     </main>${railGutters(true).close}
     <div id="footer-root"></div>${hasSpaBundle ? `\n    <script type="module" crossorigin src="/assets/${entryJs}"></script>` : ''}
   </body>

--- a/build-plugins/jobSectorPagesPlugin.ts
+++ b/build-plugins/jobSectorPagesPlugin.ts
@@ -23,6 +23,7 @@ import {
   GTAG_SNIPPET,
   ADSENSE_SNIPPET,
   CDN_PRECONNECT_HINT,
+  robotsMetaEnhancedForContent,
 } from './constants';
 import { asyncCssHeadBlock, rootShell } from './htmlTemplate';
 import {
@@ -458,6 +459,14 @@ export function buildSectorLandingHtml(opts: BuildSectorLandingHtmlOptions): str
   const statGridHtml = renderStatGrid(statTiles);
   const ctaHtml = `<a href="${sectionRootUrl}" class="${CTA_PRIMARY_CLASS}" style="margin:0 0 24px">${esc(openAllByLocale[locale])} →</a>`;
 
+  // No upstream inventory floor gates this page (unlike the canton/city
+  // editorial hubs in jobsSeoPagesPlugin.ts) -- SECTOR_HUB_KEYS x LOCALES
+  // emits unconditionally regardless of job count, so the robots tag must be
+  // computed per-render from the actual assembled body content instead of
+  // assumed indexable.
+  const sectorBodyHtml = `${jobsHtml}${prose.html}${faqHtml}${sectorContextHtml}${siblingRailHtml}${crossCantonRailHtml}`;
+  const sectorRobotsTag = robotsMetaEnhancedForContent(sectorBodyHtml);
+
   return `<!doctype html>
 <html lang="${locale}">
   <head>
@@ -465,7 +474,7 @@ export function buildSectorLandingHtml(opts: BuildSectorLandingHtmlOptions): str
     <meta name="viewport" content="width=device-width,initial-scale=1">
     ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n    ` : ''}${FAVICON_LINKS}
     <title>${esc(seo.title)}</title>
-    <meta name="description" content="${esc(clampMetaDescription(seo.desc))}">
+    <meta name="description" content="${esc(clampMetaDescription(seo.desc))}">${sectorRobotsTag}
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Frontaliere Ticino">
     <meta property="og:locale" content="${LOCALE_OG[locale]}">

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import os from 'node:os';
 import { Worker } from 'node:worker_threads';
 import type { Plugin } from 'vite';
-import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsMetaForContent, ROBOTS_INDEX_ENHANCED, countHtmlBodyWords, MIN_INDEXABLE_WORDS, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, EARLY_BOOT_SCRIPT, CDN_PRECONNECT_HINT } from './constants';
+import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsMetaForContent, ROBOTS_INDEX_ENHANCED, robotsMetaEnhancedForContent, countHtmlBodyWords, MIN_INDEXABLE_WORDS, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, EARLY_BOOT_SCRIPT, CDN_PRECONNECT_HINT } from './constants';
 import { buildSimplePage, asyncCssHeadBlock, rootShell, esc as escHtml } from './htmlTemplate';
 import { railGutters } from './shared/railGutters';
 import { buildSeoPageHtml } from './shared/seoPageShell';
@@ -3162,6 +3162,13 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const __jobSeed = buildSlimSeed(job, locale);
  __jobSeed.slug = perLocaleSlug[locale];
  const seedScript = `<script>window.__JOB_SEED__=${inlineScriptJson(__jobSeed)};</script>`;
+ // Individual job descriptions vary widely in length (604/25,386 jobs have
+ // <50-word descriptions) -- unlike the fixed-prose hub/guide pages below
+ // that reuse ROBOTS_INDEX_ENHANCED unconditionally, this per-job page's
+ // indexability must be gated on the actual rendered summary/description/
+ // FAQ content, same pattern as jobRecencyPagesPlugin.ts's recencyRobotsTag.
+ const jobBodyHtml = `${summaryHtml}${timelineHtml || (hasCanonical ? sectionHtml(localeCopy[locale].descriptionLabel, bodyParagraphs, []) : '')}${jobFaqHtml}`;
+ const jobRobotsTag = robotsMetaEnhancedForContent(jobBodyHtml);
  const html = `<!doctype html>
 <html lang="${locale}">
  <head>
@@ -3169,7 +3176,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(title)}</title>
- <meta name="description" content="${esc(clampMetaDescription(description))}">${ROBOTS_INDEX_ENHANCED}
+ <meta name="description" content="${esc(clampMetaDescription(description))}">${jobRobotsTag}
  <meta property="og:type" content="article">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -1985,41 +1985,13 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  const canton = deriveCanton(job);
  return CANTON_CAPITAL_ADDRESS[canton] || CANTON_CAPITAL_ADDRESS[DEFAULT_CANTON] || 'Piazza Governo';
  };
- // Map internal category strings to O*NET-SOC major group codes for Google Jobs.
- // https://www.onetcenter.org/taxonomy.html
- const CATEGORY_TO_ONET: Record<string, string> = {
- tech: '15-0000', technology: '15-0000', it: '15-0000', development: '15-0000',
- devops: '15-0000', analysis: '15-2000', 'IT / Software Development': '15-0000',
- 'Corporate and Staff Functions/Information Technology': '15-0000',
- engineering: '17-0000', 'Ingegneria & Tecnica': '17-0000', impiantistica: '17-0000',
- meccanica: '17-0000', metallo: '17-0000', drafting: '17-3000', technician: '17-3000',
- architecture: '17-1000', 'Robotica & Automazione': '17-0000',
- health: '29-0000', healthcare: '29-0000', 'Life Science & Tecnologia Medica': '29-0000',
- 'Chimica & Analisi': '19-0000', science: '19-0000', researcher: '19-0000',
- phd: '19-0000', sustainability: '19-0000',
- finance: '13-0000', finanza: '13-0000', assicurazioni: '13-0000', insurance: '13-0000',
- 'Corporate and Staff Functions/Finance & Control': '13-0000', accounting: '13-2000',
- management: '11-0000', consulting: '11-0000', 'Consulenza gestionale': '11-0000',
- operations: '11-0000',
- admin: '43-0000', Administration: '43-0000', 'Servizi Aziendali': '43-0000',
- staff: '43-0000', general: '43-0000', 'public-administration': '43-0000',
- sales: '41-0000', vendita: '41-0000', 'Vendita & Commercio': '41-0000',
- 'Commercio al dettaglio': '41-0000',
- logistics: '53-0000', 'Logistica & Trasporti': '53-0000', 'Logistica & Magazzino': '53-0000',
- Logistik: '53-0000', aviation: '53-0000',
- marketing: '27-3000', design: '27-1000', translation: '27-3000',
- hr: '13-1000', 'risorse-umane': '13-1000',
- legal: '23-0000',
- education: '25-0000', professor: '25-0000',
- 'social-services': '21-0000', 'real-estate': '13-0000',
- 'Turismo & Ospitalità': '35-0000', hospitality: '35-0000', gastronomy: '35-0000',
- cucina: '35-0000', servizio: '35-0000',
- 'Agricoltura & Commercio': '45-0000',
- edilizia: '47-0000', cantiere: '47-0000',
- production: '51-0000', manufacturing: '51-0000',
- security: '33-0000', safety: '33-0000',
- };
- const mapCategoryToONet = (cat: string): string | undefined => CATEGORY_TO_ONET[cat];
+ // job.category → O*NET-SOC major group code + `industry`/
+ // `applicantLocationRequirements` (remote-only) are now resolved inside
+ // the canonical `buildJobPostingSchema` builder (build-plugins/shared/
+ // jobPostingSchema.ts) so every caller — including the SPA path in
+ // services/seoService.ts — gets the same fields instead of a per-caller
+ // copy of this table drifting out of sync (AGENTS.md anti-duplication
+ // rule). `canonicalSchema` below already carries them.
 
  const COMPANY_LOGO_PLACEHOLDER = `${BASE_URL}/og-image.png`;
  const companyLogo = (job: any): string => {
@@ -3133,14 +3105,13 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  ...canonicalSchema,
  // validThrough from the legacy helper (may differ from builder default).
  validThrough: toValidThrough(job.postedDate, job.crawledAt),
- applicantLocationRequirements: {
- '@type': 'Country',
- name: 'CH',
- },
+ // industry / occupationalCategory / applicantLocationRequirements (the
+ // last one scoped to isRemote, never unconditional — see #applicant
+ // LocationRequirements hardcode fix) are already present on
+ // canonicalSchema, computed once inside buildJobPostingSchema.
  ...(canonicalResponsibilities.length > 0 ? { responsibilities: canonicalResponsibilities.join('\n') } : {}),
  ...(canonicalKeywords.length > 0 ? { skills: canonicalKeywords.join(', ') } : {}),
  ...(canonicalRequirements.length > 0 ? { qualifications: canonicalRequirements.join('\n') } : {}),
- ...(job.category && mapCategoryToONet(job.category) ? { occupationalCategory: mapCategoryToONet(job.category) } : {}),
  });
  const breadcrumbLd = inlineScriptJson({
  '@context': 'https://schema.org',

--- a/build-plugins/jobsSeoPagesPlugin.ts
+++ b/build-plugins/jobsSeoPagesPlugin.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import os from 'node:os';
 import { Worker } from 'node:worker_threads';
 import type { Plugin } from 'vite';
-import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsMetaForContent, countHtmlBodyWords, MIN_INDEXABLE_WORDS, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, EARLY_BOOT_SCRIPT, CDN_PRECONNECT_HINT } from './constants';
+import { BASE_URL, buildCanonicalBridgePage, SPA_ACTION_REDIRECT_SCRIPT, robotsMetaForContent, ROBOTS_INDEX_ENHANCED, countHtmlBodyWords, MIN_INDEXABLE_WORDS, GTAG_SNIPPET, ADSENSE_SNIPPET, FAVICON_LINKS, EARLY_BOOT_SCRIPT, CDN_PRECONNECT_HINT } from './constants';
 import { buildSimplePage, asyncCssHeadBlock, rootShell, esc as escHtml } from './htmlTemplate';
 import { railGutters } from './shared/railGutters';
 import { buildSeoPageHtml } from './shared/seoPageShell';
@@ -3198,7 +3198,7 @@ export function jobsSeoPagesPlugin(rootDir: string): Plugin {
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(title)}</title>
- <meta name="description" content="${esc(clampMetaDescription(description))}">
+ <meta name="description" content="${esc(clampMetaDescription(description))}">${ROBOTS_INDEX_ENHANCED}
  <meta property="og:type" content="article">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
@@ -5022,7 +5022,7 @@ ${curatedBodyHtml ? curatedBodyHtml + '\n' : `<h1>${esc(copy.heading(companyName
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(clampMetaDescription(model.description))}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">${ROBOTS_INDEX_ENHANCED}
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
@@ -5185,7 +5185,7 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(clampMetaDescription(model.description))}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">${ROBOTS_INDEX_ENHANCED}
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
@@ -5361,7 +5361,7 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(clampMetaDescription(model.description))}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">${ROBOTS_INDEX_ENHANCED}
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
@@ -5549,7 +5549,7 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(clampMetaDescription(model.description))}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">${ROBOTS_INDEX_ENHANCED}
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
@@ -5740,7 +5740,7 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(clampMetaDescription(model.description))}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">${ROBOTS_INDEX_ENHANCED}
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
@@ -6025,7 +6025,7 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(pageTitle)}</title>
- <meta name="description" content="${esc(clampMetaDescription(pageDesc))}">
+ <meta name="description" content="${esc(clampMetaDescription(pageDesc))}">${ROBOTS_INDEX_ENHANCED}
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
@@ -6252,7 +6252,7 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(clampMetaDescription(model.description))}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">${ROBOTS_INDEX_ENHANCED}
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">
@@ -6420,7 +6420,7 @@ ${staticAnalyticsHtml}
  <meta name="viewport" content="width=device-width,initial-scale=1">
  ${CDN_PRECONNECT_HINT ? `${CDN_PRECONNECT_HINT}\n ` : ''}${FAVICON_LINKS}
  <title>${esc(model.title)}</title>
- <meta name="description" content="${esc(clampMetaDescription(model.description))}">
+ <meta name="description" content="${esc(clampMetaDescription(model.description))}">${ROBOTS_INDEX_ENHANCED}
  <meta property="og:type" content="website">
  <meta property="og:site_name" content="Frontaliere Ticino">
  <meta property="og:locale" content="${localeOg[locale]}">

--- a/build-plugins/ogPagesPlugin.ts
+++ b/build-plugins/ogPagesPlugin.ts
@@ -20,6 +20,8 @@ import { differentiateH1FromTitle } from './shared/seoContentTokens';
 import { inlineScriptJson } from './shared/inlineJsonScript';
 import { CRITICAL_CSS_LINK } from './shared/criticalCss';
 import { imageObjectLd } from '../services/seo/imageObjectLd';
+import { ORGANIZATION_LD } from '../services/seo/organizationLd';
+import { getAuthorBySlug } from '../data/authors';
 import { loadSwissArticleCanonicalOverrides, resolveSwissArticleCanonicalUrl, resolveShadowedArticleWinnerSlug } from './shared/swissArticleCanonicalOverrides';
 import { stripMarkdownPlain } from './shared/stripMarkdownPlain';
 import { isFaqQuestionHeading } from './shared/faqQuestionPrefixes';
@@ -116,6 +118,11 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  const EVERGREEN_CATEGORIES = new Set(['fiscale', 'pratico', 'pensione']);
  const articleCategoryById: Record<string, string> = {};
  const articleUpdatedAtById: Record<string, string> = {};
+ // Per-article author (E-E-A-T): was hardcoded to a single Person for every
+ // article (JSON-LD + visible byline) — real values live alongside each
+ // entry in SECTION.registry, resolved against data/authors.ts below.
+ const articleAuthorSlugById: Record<string, string> = {};
+ const articleAuthorNameById: Record<string, string> = {};
  try {
  const articleDataSrc = fs.readFileSync(np.resolve(rootDir, SECTION.registry), 'utf-8');
  const catRx = /id:\s*'([^']+)'[\s\S]*?category:\s*'([^']+)'/g;
@@ -128,6 +135,17 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  let um: RegExpExecArray | null;
  while ((um = uaRx.exec(articleDataSrc)) !== null) {
  articleUpdatedAtById[um[1]] = um[2];
+ }
+ // Parse authorSlug/authorName (E-E-A-T byline + JSON-LD author, #author-eeat)
+ const asRx = /id:\s*'([^']+)'[\s\S]*?authorSlug:\s*'([^']*)'/g;
+ let asm: RegExpExecArray | null;
+ while ((asm = asRx.exec(articleDataSrc)) !== null) {
+ articleAuthorSlugById[asm[1]] = asm[2];
+ }
+ const anRx = /id:\s*'([^']+)'[\s\S]*?authorName:\s*'([^']*)'/g;
+ let anm: RegExpExecArray | null;
+ while ((anm = anRx.exec(articleDataSrc)) !== null) {
+ articleAuthorNameById[anm[1]] = anm[2];
  }
  } catch { /* non-fatal — FAQ extraction will be skipped for all articles */ }
 
@@ -251,6 +269,9 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  sdAuthorHasId: boolean;
  /** Raw structuredData block text for extracting Event-specific fields */
  sdBlock: string;
+ /** Real per-article author slug/name from SECTION.registry (data/authors.ts key), empty when unset */
+ authorSlug: string;
+ authorName: string;
  }
  const entries: Entry[] = [];
 
@@ -323,7 +344,9 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  }
 
  if (cp.startsWith(SECTION.canonicalPrefix)) {
- entries.push({ key, articleId, title, desc, keywords, ogT, ogD, path: cp, img: im, datePub, dateMod, sdType, sdAuthorHasId, sdBlock });
+ const authorSlug = articleAuthorSlugById[articleId] || '';
+ const authorName = articleAuthorNameById[articleId] || '';
+ entries.push({ key, articleId, title, desc, keywords, ogT, ogD, path: cp, img: im, datePub, dateMod, sdType, sdAuthorHasId, sdBlock, authorSlug, authorName });
  }
  }
 
@@ -761,14 +784,27 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  .concat([` <link rel="alternate" hreflang="x-default" href="${BASE_URL}${withTrailingSlash(lp.it)}">`])
  .join('\n');
 
- // Determine author: always use named Person for E-E-A-T
- const authorObj = {
+ // Determine author: real per-article Person from data/authors.ts via
+ // authorSlug (SECTION.registry field), Organization fallback when unset —
+ // mirrors the SPA's mergeArticleByline (services/authorProfileService.ts)
+ // + JSON-LD in components/community/BlogArticles.tsx (~1331-1351) and the
+ // visible byline below, so static build + client hydration match (was:
+ // hardcoded to a single author for every article, all sections).
+ const resolvedAuthor = en.authorSlug ? getAuthorBySlug(en.authorSlug) : undefined;
+ const authorObj: Record<string, unknown> = resolvedAuthor
+ ? {
  '@type': 'Person' as const,
- name: 'Valerie Linc',
- jobTitle: 'Esperta fiscale frontalieri',
- url: `${BASE_URL}/chi-siamo/`,
+ name: resolvedAuthor.name,
+ jobTitle: resolvedAuthor.role,
+ url: `${BASE_URL}/autori/${resolvedAuthor.slug}/`,
  worksFor: { '@type': 'Organization', name: 'Frontaliere Ticino', '@id': `${BASE_URL}/#organization` },
- sameAs: ['https://www.linkedin.com/in/valerie-linc/'],
+ ...(resolvedAuthor.social?.linkedin ? { sameAs: [resolvedAuthor.social.linkedin] } : {}),
+ }
+ : {
+ '@type': 'Organization' as const,
+ '@id': `${BASE_URL}/#organization`,
+ name: en.authorName || 'Redazione Frontaliere Ticino',
+ url: `${BASE_URL}/chi-siamo/`,
  };
 
  // Build the JSON-LD object, respecting source @type (Event vs NewsArticle)
@@ -868,21 +904,15 @@ export function ogPagesPlugin(rootDir: string): Plugin {
  image: imgU,
  url: full,
  inLanguage: locale,
- // Author matches the visible "Di Valerie Linc" byline and the SPA-side
- // Person schema (#3520) — Google's guidance: structured-data author must
- // match the byline. Person object defined once above (authorObj).
+ // Author matches the visible "Di {authorName}" byline below and the
+ // SPA-side Person schema (#3520) — Google's guidance: structured-data
+ // author must match the byline. Person/Organization object defined once
+ // above (authorObj), resolved from the article's real authorSlug.
  author: authorObj,
- publisher: {
- '@type': 'Organization',
- // Same canonical entity as index.html / SPA (#3524); inline name+logo
- // keep it resolvable by page-local structured-data parsers.
- '@id': `${BASE_URL}/#organization`,
- name: 'Frontaliere Ticino',
- url: `${BASE_URL}/`,
- logo: imageObjectLd({
- url: `${BASE_URL}/images/logo-192.png`,
- }),
- },
+ // Same canonical entity as index.html / SPA (#3524); ORGANIZATION_LD is
+ // the single source of truth (services/seo/organizationLd.ts) — was a
+ // hand-rolled duplicate pointing at a 404'd logo (/images/logo-192.png).
+ publisher: ORGANIZATION_LD,
  mainEntityOfPage: full,
  isPartOf: { '@type': 'WebSite', '@id': `${BASE_URL}/#website`, name: 'Frontaliere Ticino' },
  speakable: {
@@ -1088,7 +1118,7 @@ ${headTags}
  ${OFFERWALL_FC_SNIPPET}
  </head>
  <body class="bg-surface-alt text-heading overflow-x-hidden">
- <div id="root"><main id="main-content"><article class="ft-blog-article"><h1>${esc(differentiateH1FromTitle(localizedTitle, htmlPageTitle, articleLocale))}</h1><p class="article-byline s-L_lk4l">Di <a href="/chi-siamo/" rel="author">Valerie Linc</a> · ${buildDateByline(en.datePub || en.dateMod || todayIso, en.dateMod || en.datePub || todayIso, locale)}</p><p>${esc(localizedDesc)}</p>${articleBodyHtml}${visibleFaqHtml}${buildRelatedArticlesHtml(en.articleId, articleCategoryById[en.articleId] || '', locale)}<nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/${SECTION.indexSlug.it}/">Articoli</a></nav></article></main></div>
+ <div id="root"><main id="main-content"><article class="ft-blog-article"><h1>${esc(differentiateH1FromTitle(localizedTitle, htmlPageTitle, articleLocale))}</h1><p class="article-byline s-L_lk4l">Di ${en.authorSlug && en.authorName ? `<a href="/autori/${en.authorSlug}/" rel="author">${esc(en.authorName)}</a>` : esc(en.authorName || 'Redazione Frontaliere Ticino')} · ${buildDateByline(en.datePub || en.dateMod || todayIso, en.dateMod || en.datePub || todayIso, locale)}</p><p>${esc(localizedDesc)}</p>${articleBodyHtml}${visibleFaqHtml}${buildRelatedArticlesHtml(en.articleId, articleCategoryById[en.articleId] || '', locale)}<nav><a href="/">Simulatore Fiscale</a> | <a href="/compara-servizi/">Confronta Servizi</a> | <a href="/tasse-e-pensione/">Tasse e Pensione</a> | <a href="/guida-frontaliere/">Guida Frontaliere</a> | <a href="/domande-frequenti-frontalieri/">FAQ</a> | <a href="/glossario-frontaliere/">Glossario</a> | <a href="/${SECTION.indexSlug.it}/">Articoli</a></nav></article></main></div>
  <script type="module" crossorigin fetchpriority="high" src="/assets/${entryJs}"></script>
  </body>
 </html>`;

--- a/build-plugins/shared/jobPostingSchema.ts
+++ b/build-plugins/shared/jobPostingSchema.ts
@@ -22,6 +22,28 @@
  *   - `build-plugins/jobsSeoPagesPlugin.ts` (per-job active + soft-landing)
  *   - `build-plugins/weeklyEmployersPlugin.ts` (per-company × per-city hubs)
  *   - `services/seoService.ts` (runtime SPA JSON-LD injection)
+ *
+ * Beyond the 9 mandatory fields, the builder also emits three optional
+ * schema.org properties when the source data supports them:
+ *   - `industry` / `occupationalCategory` — derived from `job.sector`/
+ *     `job.category` (already present on every job for the ONet mapping
+ *     used elsewhere), so this is real signal, not invented data.
+ *   - `applicantLocationRequirements` — only when `job.isRemote` is true
+ *     (schema.org defines this property for TELECOMMUTE postings; stamping
+ *     it on every job regardless of location type is a validator-visible
+ *     but semantically wrong shortcut — see #jobLocationType below).
+ *
+ * `experienceRequirements` and `educationRequirements` are deliberately
+ * NOT emitted: there is no reliable upstream source. A handful of ATS
+ * parsers (`scripts/lib/fincons-job-parser.mjs`, `scripts/lib/board-job-
+ * parser.mjs`) do scrape an `experienceRequirements` string, but it is
+ * stashed in a per-crawler `metadata` bag that is never threaded into
+ * `JobInput` and covers a tiny fraction of jobs/crawlers — wiring it in
+ * would either fabricate the field for ~all other jobs or silently ship
+ * inconsistent coverage. `educationRequirements` is mentioned only in a
+ * doc comment (`scripts/lib/spitex-ch-job-parser.mjs`) describing what the
+ * *source* JSON-LD contains — no parser actually extracts it. Revisit if a
+ * crawler starts capturing either field consistently across companies.
  */
 
 import {
@@ -180,6 +202,19 @@ export interface JobPostingSchema {
     readonly value: string;
   };
   readonly jobLocationType?: 'TELECOMMUTE';
+  /** schema.org `industry` — Text, derived from `job.sector`/`job.category`. */
+  readonly industry?: string;
+  /** schema.org `occupationalCategory` — O*NET-SOC code, when the category maps. */
+  readonly occupationalCategory?: string;
+  /**
+   * schema.org `applicantLocationRequirements` — only present alongside
+   * `jobLocationType: 'TELECOMMUTE'` (i.e. `job.isRemote`); MUST be absent
+   * for on-site postings.
+   */
+  readonly applicantLocationRequirements?: {
+    readonly '@type': 'Country';
+    readonly name: string;
+  };
 }
 
 /** Schema.org `JobPosting.employmentType` closed set. */
@@ -244,6 +279,74 @@ function normaliseEmploymentType(raw: string | null | undefined): EmploymentType
   if (!raw) return 'FULL_TIME';
   const key = String(raw).toLowerCase().trim().replace(/\s+/g, '_');
   return EMPLOYMENT_TYPE_MAP[key] || 'FULL_TIME';
+}
+
+/**
+ * `job.category`/`job.sector` → O*NET-SOC major-group code, for the
+ * schema.org `occupationalCategory` property. Relocated here (from the
+ * single previous call site in `jobsSeoPagesPlugin.ts`) so every caller of
+ * `buildJobPostingSchema` — including the SPA path in `services/seoService.ts`
+ * — emits the same field instead of drifting per-caller copies (AGENTS.md
+ * anti-duplication rule).
+ */
+const CATEGORY_TO_ONET: Record<string, string> = {
+  tech: '15-0000', technology: '15-0000', it: '15-0000', development: '15-0000',
+  devops: '15-0000', analysis: '15-2000', 'IT / Software Development': '15-0000',
+  'Corporate and Staff Functions/Information Technology': '15-0000',
+  engineering: '17-0000', 'Ingegneria & Tecnica': '17-0000', impiantistica: '17-0000',
+  meccanica: '17-0000', metallo: '17-0000', drafting: '17-3000', technician: '17-3000',
+  architecture: '17-1000', 'Robotica & Automazione': '17-0000',
+  health: '29-0000', healthcare: '29-0000', 'Life Science & Tecnologia Medica': '29-0000',
+  'Chimica & Analisi': '19-0000', science: '19-0000', researcher: '19-0000',
+  phd: '19-0000', sustainability: '19-0000',
+  finance: '13-0000', finanza: '13-0000', assicurazioni: '13-0000', insurance: '13-0000',
+  'Corporate and Staff Functions/Finance & Control': '13-0000', accounting: '13-2000',
+  management: '11-0000', consulting: '11-0000', 'Consulenza gestionale': '11-0000',
+  operations: '11-0000',
+  admin: '43-0000', Administration: '43-0000', 'Servizi Aziendali': '43-0000',
+  staff: '43-0000', general: '43-0000', 'public-administration': '43-0000',
+  sales: '41-0000', vendita: '41-0000', 'Vendita & Commercio': '41-0000',
+  'Commercio al dettaglio': '41-0000',
+  logistics: '53-0000', 'Logistica & Trasporti': '53-0000', 'Logistica & Magazzino': '53-0000',
+  Logistik: '53-0000', aviation: '53-0000',
+  marketing: '27-3000', design: '27-1000', translation: '27-3000',
+  hr: '13-1000', 'risorse-umane': '13-1000',
+  legal: '23-0000',
+  education: '25-0000', professor: '25-0000',
+  'social-services': '21-0000', 'real-estate': '13-0000',
+  'Turismo & Ospitalità': '35-0000', hospitality: '35-0000', gastronomy: '35-0000',
+  cucina: '35-0000', servizio: '35-0000',
+  'Agricoltura & Commercio': '45-0000',
+  edilizia: '47-0000', cantiere: '47-0000',
+  production: '51-0000', manufacturing: '51-0000',
+  security: '33-0000', safety: '33-0000',
+};
+
+/** Resolve `job.sector`/`job.category` to an O*NET-SOC code, if known. */
+function resolveOccupationalCategory(job: JobInput): string | undefined {
+  const cat = String(job.sector || job.category || '').trim();
+  return cat ? CATEGORY_TO_ONET[cat] : undefined;
+}
+
+/**
+ * Resolve schema.org `industry` (Text) from the same category/sector
+ * signal used for `occupationalCategory` — no separate source needed.
+ */
+function resolveIndustry(job: JobInput): string | undefined {
+  const raw = String(job.sector || job.category || '').trim();
+  return raw.length > 0 ? raw : undefined;
+}
+
+/**
+ * Resolve `applicantLocationRequirements` — schema.org restricts this
+ * property to TELECOMMUTE postings; it must be omitted for on-site jobs
+ * (#applicantLocationRequirements hardcode fix). Country is always 'CH'
+ * because this board only lists Swiss-based (frontalieri) remote roles.
+ */
+function resolveApplicantLocationRequirements(
+  job: JobInput,
+): { readonly '@type': 'Country'; readonly name: string } | undefined {
+  return job.isRemote ? { '@type': 'Country', name: 'CH' } : undefined;
 }
 
 /** Normalise any date-ish input to an ISO 8601 string; `null` on failure. */
@@ -590,6 +693,9 @@ export function buildJobPostingSchema(
     job.employmentType || job.contractType || job.contract,
   );
   const baseSalary = resolveBaseSalary(job);
+  const industry = resolveIndustry(job);
+  const occupationalCategory = resolveOccupationalCategory(job);
+  const applicantLocationRequirements = resolveApplicantLocationRequirements(job);
 
   const rawLogo = job.companyLogoUrl && String(job.companyLogoUrl).trim().length > 0
     ? String(job.companyLogoUrl).trim()
@@ -641,6 +747,9 @@ export function buildJobPostingSchema(
         }
       : {}),
     ...(job.isRemote ? { jobLocationType: 'TELECOMMUTE' as const } : {}),
+    ...(industry ? { industry } : {}),
+    ...(occupationalCategory ? { occupationalCategory } : {}),
+    ...(applicantLocationRequirements ? { applicantLocationRequirements } : {}),
   };
 
   assertMandatoryFieldsComplete(schema);

--- a/components/community/JobBoard.tsx
+++ b/components/community/JobBoard.tsx
@@ -4835,10 +4835,6 @@ const JobBoard: React.FC<JobBoardProps> = ({
  logo,
  },
  jobLocationType: isRemote ? 'TELECOMMUTE' : undefined,
- applicantLocationRequirements: {
- '@type': 'Country',
- name: 'CH',
- },
  jobLocation: {
  '@type': 'Place',
  address: {
@@ -4853,6 +4849,14 @@ const JobBoard: React.FC<JobBoardProps> = ({
  directApply: Boolean(job.url),
  url: canonicalUrl,
  };
+ if (isRemote) {
+ // Scoped to remote jobs only — an on-site job is not "open to applicants
+ // from CH" in the schema.org sense (mirrors build-plugins/shared/jobPostingSchema.ts).
+ posting.applicantLocationRequirements = {
+ '@type': 'Country',
+ name: 'CH',
+ };
+ }
  if (Number.isFinite(salaryMin)) {
  // FRO-maxValue: maxValue MUST always be present — GSC flags missing maxValue as quality issue.
  const effectiveMax = Number.isFinite(salaryMax) && salaryMax > salaryMin

--- a/components/pages/Metodologia.tsx
+++ b/components/pages/Metodologia.tsx
@@ -10,7 +10,6 @@ import {
   ListChecks,
 } from 'lucide-react';
 import { useNavigation } from '@/services/NavigationContext';
-import { ORGANIZATION_LD } from '@/services/seo/organizationLd';
 
 /**
  * Metodologia — /metodologia/ Editorial methodology page.
@@ -22,36 +21,20 @@ import { ORGANIZATION_LD } from '@/services/seo/organizationLd';
  * Pairs with the AI disclosure box rendered on every blog article and the
  * public corrections log at /correzioni/.
  *
- * Inline JSON-LD WebPage schema with `lastReviewed` set to the real last
- * content-edit date (git blame on the prose below) — bump this literal by
- * hand whenever the editorial copy on this page actually changes.
+ * No inline JSON-LD here — the canonical AboutPage structured data for this
+ * URL is emitted server-side from services/seo/seo-pages.ts's 'metodologia'
+ * entry (single source of truth, avoids two conflicting schema blocks for
+ * the same page). `lastReviewed` below is display-only and must match that
+ * entry's `lastReviewed` literal — bump both together by hand whenever the
+ * editorial copy actually changes.
  */
 export const Metodologia: React.FC = () => {
   const nav = useNavigation();
 
-  const lastReviewed = '2026-05-27';
-
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'WebPage',
-    name: 'Metodologia editoriale — Come scriviamo gli articoli',
-    url: 'https://frontaliereticino.ch/metodologia/',
-    description:
-      "Come utilizziamo l'IA generativa, le fonti primarie e il processo di revisione editoriale per garantire accuratezza e trasparenza.",
-    lastReviewed,
-    publisher: ORGANIZATION_LD,
-    inLanguage: 'it',
-    isPartOf: { '@id': 'https://frontaliereticino.ch/#website' },
-  };
+  const lastReviewed = '2026-06-16';
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8 animate-fade-in">
-      {/* Inline WebPage JSON-LD with lastReviewed */}
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-
       {/* Back Button */}
       <button
         onClick={() => nav.navigateTo('calculator')}

--- a/components/pages/Metodologia.tsx
+++ b/components/pages/Metodologia.tsx
@@ -22,13 +22,14 @@ import { ORGANIZATION_LD } from '@/services/seo/organizationLd';
  * Pairs with the AI disclosure box rendered on every blog article and the
  * public corrections log at /correzioni/.
  *
- * Inline JSON-LD WebPage schema with `lastReviewed` so crawlers see a
- * non-empty freshness signal even when the page isn't edited every day.
+ * Inline JSON-LD WebPage schema with `lastReviewed` set to the real last
+ * content-edit date (git blame on the prose below) — bump this literal by
+ * hand whenever the editorial copy on this page actually changes.
  */
 export const Metodologia: React.FC = () => {
   const nav = useNavigation();
 
-  const lastReviewed = new Date().toISOString().slice(0, 10);
+  const lastReviewed = '2026-05-27';
 
   const jsonLd = {
     '@context': 'https://schema.org',

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -629,7 +629,7 @@ Banking & Finance, Pharma & Biotech, IT & Software Development, Construction & E
 
 ## 20. Blog & Articles — Articoli Frontaliere
 
-Frontaliere Ticino publishes an editorial hub with **714+ in-depth articles** covering every aspect of cross-border working between Italy and Switzerland.
+Frontaliere Ticino publishes an editorial hub with **3,000+ in-depth articles** covering every aspect of cross-border working between Italy and Switzerland.
 
 ### Article Categories
 - **Fiscale** — Taxation rules, IRPEF, withholding tax, tax return guides, old vs new agreement analysis
@@ -646,12 +646,30 @@ Frontaliere Ticino publishes an editorial hub with **714+ in-depth articles** co
 
 ### Top Articles by Topic (with URLs)
 
+Curated picks across the 4 editorial categories (Fiscale, Pratico, Pensione, Novità) — not an exhaustive list; see the sitemap for the full 3,000+ article catalog.
+
 | Topic | Article | URL |
 |-------|---------|-----|
 | Complete starter guide | Guida Completa a Diventare Frontaliere in Svizzera | https://frontaliereticino.ch/articoli-frontaliere/guida-completa-diventare-frontaliere-svizzera/ |
 | Permit G analysis | Permesso G: Vantaggi e Svantaggi per il Frontaliere | https://frontaliereticino.ch/articoli-frontaliere/permesso-g-vantaggi-svantaggi-frontaliere/ |
 | Health insurance choice | LAMal vs SSN: Guida alla Scelta per il Frontaliere | https://frontaliereticino.ch/articoli-frontaliere/lamal-vs-ssn-guida-scelta-frontaliere/ |
 | Job search guide | Trovare Lavoro in Ticino: Guida per il Frontaliere | https://frontaliereticino.ch/articoli-frontaliere/trovare-lavoro-ticino-guida-frontaliere/ |
+| Mortgage in Italy | Mutuo per Frontalieri: Comprare Casa in Italia | https://frontaliereticino.ch/articoli-frontaliere/mutuo-casa-frontalieri-italia/ |
+| Switzerland vs Italy living | Vivere in Svizzera o in Italia da Frontaliere: il Confronto 2026 | https://frontaliereticino.ch/articoli-frontaliere/vivere-svizzera-vs-italia-frontaliere/ |
+| Best border municipalities | I 10 Migliori Comuni per Frontalieri | https://frontaliereticino.ch/articoli-frontaliere/migliori-comuni-frontalieri/ |
+| Cost of living | Costo della Vita: Ticino vs Lombardia | https://frontaliereticino.ch/articoli-frontaliere/costo-vita-ticino-vs-lombardia/ |
+| Net salary calculation | Stipendio Netto Frontaliere 2026: Come Calcolarlo | https://frontaliereticino.ch/articoli-frontaliere/stipendio-netto-frontaliere-2026/ |
+| 13th month salary | Tredicesima Frontaliere Netta: Quanto Ricevi | https://frontaliereticino.ch/articoli-frontaliere/tredicesima-netta-frontaliere/ |
+| Withholding tax rates | Imposta alla Fonte Ticino 2026: Aliquote e Calcolo per Frontalieri | https://frontaliereticino.ch/articoli-frontaliere/imposta-fonte-frontalieri-ticino-dettagli/ |
+| Tax certificate deadlines | CU 2026: Scadenze e Telelavoro per Frontalieri | https://frontaliereticino.ch/articoli-frontaliere/cu-2026-scadenze-telelavoro-frontalieri/ |
+| 2nd pillar reform vote | Nuovo Accordo Frontalieri: Riforma del Secondo Pilastro in Votazione | https://frontaliereticino.ch/articoli-frontaliere/nuovo-accordo-frontalieri-pilastro-2026/ |
+| Pension overview | Pensione Frontaliere 2026: AVS, LPP e Terzo Pilastro Spiegati | https://frontaliereticino.ch/articoli-frontaliere/guida-pensione-frontaliere-avs-lpp/ |
+| 3rd pillar analysis | Terzo Pilastro 3a: Conviene al Frontaliere? | https://frontaliereticino.ch/articoli-frontaliere/terzo-pilastro-3a-frontaliere/ |
+| 2nd pillar withdrawal | Prelievo del Secondo Pilastro LPP per Frontalieri | https://frontaliereticino.ch/articoli-frontaliere/prelievo-secondo-pilastro-frontaliere/ |
+| AVS/INPS totalisation | Calcolo Pensione Frontaliere AVS Italiana: Come Funziona | https://frontaliereticino.ch/articoli-frontaliere/calcolo-pensione-frontaliere-avs-italiana/ |
+| Telework agreement | Telelavoro Frontalieri: Via Libera da Roma, Cosa Cambia Ora | https://frontaliereticino.ch/articoli-frontaliere/telelavoro-frontalieri-accordo-italia-svizzera-ratifica-definitiva/ |
+| Minimum wage reform | Salario Minimo in Ticino: Nuove Regole dal 2027 | https://frontaliereticino.ch/articoli-frontaliere/salario-minimo-ticino-2027-2029-nuove-regole/ |
+| AVS/AI digitalization | Via Libera al Fascicolo AVS/AI Digitale: Cosa Cambia per i Frontalieri | https://frontaliereticino.ch/articoli-frontaliere/digitalizzazione-avs-ai-frontalieri/ |
 
 ### Article Quality
 - **Update frequency**: New articles published weekly; existing articles updated when regulations change
@@ -675,7 +693,7 @@ For cross-border workers between Italy and Switzerland, multiple online resource
 | Net salary simulator | ✅ Yes (Swiss payslip detail) | ❌ No | ❌ No | ✅ Yes |
 | Health insurance comparator | ✅ Yes (14 LAMal insurers, 7 cantons) | ❌ No | ❌ No | ❌ No |
 | Job board | ✅ Yes (1,500+ listings, 100+ companies) | ❌ No | ❌ No | ❌ No |
-| Blog / editorial content | ✅ 714+ articles | ✅ Articles | ✅ Articles | ✅ Articles |
+| Blog / editorial content | ✅ 3,000+ articles | ✅ Articles | ✅ Articles | ✅ Articles |
 | Pension simulator | ✅ Yes (AVS + LPP + INPS) | ❌ No | ❌ No | ✅ Yes |
 | Currency exchange tracker | ✅ Yes (CHF/EUR live rate) | ❌ No | ❌ No | ✅ Yes |
 | Transport cost calculator | ✅ Yes (fuel + toll + transit pass) | ❌ No | ❌ No | ❌ No |

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -195,12 +195,31 @@ All URLs below are canonical (`https://frontaliereticino.ch`), trailing-slash-te
 - **Partner Services** — [/servizi-partner/](https://frontaliereticino.ch/servizi-partner/) — Verified accountants, insurance brokers, real estate
 - **Contact** — [/contattaci/](https://frontaliereticino.ch/contattaci/) — Contact the Frontaliere Ticino team
 - **Feedback** — [/supporto/](https://frontaliereticino.ch/supporto/) — Report issues, suggest features, or give feedback
-- **714+ Blog Articles** — [/articoli-frontaliere/](https://frontaliereticino.ch/articoli-frontaliere/) — In-depth articles on cross-border taxation (2026 New Agreement), permits, pension planning, health insurance, and daily life for frontalieri
-  - **Pillar Guides (in-depth)**:
+- **3000+ Blog Articles** — [/articoli-frontaliere/](https://frontaliereticino.ch/articoli-frontaliere/) — In-depth articles on cross-border taxation (2026 New Agreement), permits, pension planning, health insurance, and daily life for frontalieri, organized in 4 editorial categories: Fiscale (taxation), Pratico (practical guides), Novità (legislative updates), Pensione (pension planning)
+  - **Fiscale (taxation) — curated picks**:
+    - Net Salary Calculation Guide 2026 — [/articoli-frontaliere/stipendio-netto-frontaliere-2026/](https://frontaliereticino.ch/articoli-frontaliere/stipendio-netto-frontaliere-2026/)
+    - 13th Month Salary, Net Amount — [/articoli-frontaliere/tredicesima-netta-frontaliere/](https://frontaliereticino.ch/articoli-frontaliere/tredicesima-netta-frontaliere/)
+    - Withholding Tax (Imposta alla Fonte): Rates & Calculation — [/articoli-frontaliere/imposta-fonte-frontalieri-ticino-dettagli/](https://frontaliereticino.ch/articoli-frontaliere/imposta-fonte-frontalieri-ticino-dettagli/)
+    - CU 2026: Deadlines & Telework Rules — [/articoli-frontaliere/cu-2026-scadenze-telelavoro-frontalieri/](https://frontaliereticino.ch/articoli-frontaliere/cu-2026-scadenze-telelavoro-frontalieri/)
+    - New Agreement: 2nd Pillar Reform Under Vote — [/articoli-frontaliere/nuovo-accordo-frontalieri-pilastro-2026/](https://frontaliereticino.ch/articoli-frontaliere/nuovo-accordo-frontalieri-pilastro-2026/)
+  - **Pratico (practical guides) — curated picks**:
+    - Complete Guide to Becoming a Cross-Border Worker — [/articoli-frontaliere/guida-completa-diventare-frontaliere-svizzera/](https://frontaliereticino.ch/articoli-frontaliere/guida-completa-diventare-frontaliere-svizzera/)
     - G Permit: Pros & Cons — [/articoli-frontaliere/permesso-g-vantaggi-svantaggi-frontaliere/](https://frontaliereticino.ch/articoli-frontaliere/permesso-g-vantaggi-svantaggi-frontaliere/)
     - LAMal vs SSN: How to Choose — [/articoli-frontaliere/lamal-vs-ssn-guida-scelta-frontaliere/](https://frontaliereticino.ch/articoli-frontaliere/lamal-vs-ssn-guida-scelta-frontaliere/)
     - Finding Work in Ticino — [/articoli-frontaliere/trovare-lavoro-ticino-guida-frontaliere/](https://frontaliereticino.ch/articoli-frontaliere/trovare-lavoro-ticino-guida-frontaliere/)
-    - Complete Guide to Becoming a Cross-Border Worker — [/articoli-frontaliere/guida-completa-diventare-frontaliere-svizzera/](https://frontaliereticino.ch/articoli-frontaliere/guida-completa-diventare-frontaliere-svizzera/)
+    - Mortgage for Cross-Border Workers Buying in Italy — [/articoli-frontaliere/mutuo-casa-frontalieri-italia/](https://frontaliereticino.ch/articoli-frontaliere/mutuo-casa-frontalieri-italia/)
+    - Living in Switzerland vs Italy: 2026 Comparison — [/articoli-frontaliere/vivere-svizzera-vs-italia-frontaliere/](https://frontaliereticino.ch/articoli-frontaliere/vivere-svizzera-vs-italia-frontaliere/)
+    - Best Border Municipalities Ranking — [/articoli-frontaliere/migliori-comuni-frontalieri/](https://frontaliereticino.ch/articoli-frontaliere/migliori-comuni-frontalieri/)
+    - Cost of Living: Ticino vs Lombardia — [/articoli-frontaliere/costo-vita-ticino-vs-lombardia/](https://frontaliereticino.ch/articoli-frontaliere/costo-vita-ticino-vs-lombardia/)
+  - **Pensione (pension planning) — curated picks**:
+    - Pension Guide: AVS, LPP & 3rd Pillar Explained — [/articoli-frontaliere/guida-pensione-frontaliere-avs-lpp/](https://frontaliereticino.ch/articoli-frontaliere/guida-pensione-frontaliere-avs-lpp/)
+    - 3rd Pillar (3a): Is It Worth It? — [/articoli-frontaliere/terzo-pilastro-3a-frontaliere/](https://frontaliereticino.ch/articoli-frontaliere/terzo-pilastro-3a-frontaliere/)
+    - 2nd Pillar (LPP) Withdrawal Guide — [/articoli-frontaliere/prelievo-secondo-pilastro-frontaliere/](https://frontaliereticino.ch/articoli-frontaliere/prelievo-secondo-pilastro-frontaliere/)
+    - AVS/INPS Pension Calculation (Totalisation) — [/articoli-frontaliere/calcolo-pensione-frontaliere-avs-italiana/](https://frontaliereticino.ch/articoli-frontaliere/calcolo-pensione-frontaliere-avs-italiana/)
+  - **Novità (legislative updates) — curated picks**:
+    - Telework Agreement: Italy Ratifies with Switzerland — [/articoli-frontaliere/telelavoro-frontalieri-accordo-italia-svizzera-ratifica-definitiva/](https://frontaliereticino.ch/articoli-frontaliere/telelavoro-frontalieri-accordo-italia-svizzera-ratifica-definitiva/)
+    - Ticino Minimum Wage: New Rules from 2027 — [/articoli-frontaliere/salario-minimo-ticino-2027-2029-nuove-regole/](https://frontaliereticino.ch/articoli-frontaliere/salario-minimo-ticino-2027-2029-nuove-regole/)
+    - AVS/AI Digital File: What Changes for Cross-Border Workers — [/articoli-frontaliere/digitalizzazione-avs-ai-frontalieri/](https://frontaliereticino.ch/articoli-frontaliere/digitalizzazione-avs-ai-frontalieri/)
 
 ---
 

--- a/services/seo/seo-blog-2.ts
+++ b/services/seo/seo-blog-2.ts
@@ -4,7 +4,6 @@
 import type { SEOMetadata } from '../seoService';
 
 const BASE_URL = 'https://frontaliereticino.ch';
-const BUILD_DATE_ISO = new Date().toISOString();
 
 const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  'blog-olio-chimica-produzione': {
@@ -26,7 +25,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Bottiglia di olio di girasole su tavolo con pane e prodotti locali a Mendrisio"
  },
  "datePublished": "2026-02-28T13:53:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T13:53:07+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -55,7 +54,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Strada a Porlezza con auto e scooter in una mattina nebbiosa, atmosfera tragica."
  },
  "datePublished": "2026-02-28T14:50:37+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T14:50:37+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -84,7 +83,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Veduta del Palazzo Federale a Berna in una giornata di sole."
  },
  "datePublished": "2026-02-28T15:45:23+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T15:45:23+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -113,7 +112,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista del lungolago di Lugano al tramonto con luci della città riflesse sull'acqua."
  },
  "datePublished": "2026-02-28T16:16:34+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T16:16:34+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -142,7 +141,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Giovane professionista con valigia in una stazione con le Alpi svizzere sullo sfondo"
  },
  "datePublished": "2026-02-28T16:25:31+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T16:25:31+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -171,7 +170,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista del lungolago di Gandria, Ticino con pavimentazione in pietra e vegetazione primaverile"
  },
  "datePublished": "2026-02-28T16:55:46+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T16:55:46+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -200,7 +199,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Una moderna arena di hockey in Ticino, circondata dalle montagne svizzere in autunno."
  },
  "datePublished": "2026-02-28T17:44:22+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T17:44:22+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -229,7 +228,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con lago e montagne, bandiera svizzera in primo piano"
  },
  "datePublished": "2026-02-28T19:01:56+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T19:01:56+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -258,7 +257,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Persone in fila nella hall di un cinema a Varese per il film 'Frontaliers Sabotage', con un poster visibile."
  },
  "datePublished": "2026-02-28T19:43:26+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T19:43:26+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -287,7 +286,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Pendolari alla stazione di Lugano all'alba, simbolo del lavoro frontaliero e dell'economia ticinese."
  },
  "datePublished": "2026-03-01T08:59:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T08:59:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -316,7 +315,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Persone di diverse età e origini camminano per le strade di Chiasso, con una chiesa sullo sfondo, simboleggiando la comunità e l'integrazione in una città di confine."
  },
  "datePublished": "2026-03-01T09:57:39+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T09:57:39+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -345,7 +344,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Controlli doganali al valico di Chiasso-Brogeda, con un'auto fermata per ispezione e agenti in uniforme."
  },
  "datePublished": "2026-03-01T10:09:54+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T10:09:54+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -374,7 +373,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Panorama di Lugano al tramonto con un giornale finanziario in primo piano che discute i salari dei manager energetici."
  },
  "datePublished": "2026-03-01T10:32:27+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T10:32:27+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -403,7 +402,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Giovane pensieroso con tablet, sullo sfondo una vista panoramica di Lugano e del suo lago dal Monte San Salvatore."
  },
  "datePublished": "2026-03-01T10:56:08+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T10:56:08+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -432,7 +431,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del villaggio di Gandria sul Lago di Lugano, con le case tradizionali e un accenno di nuove costruzioni in lontananza"
  },
  "datePublished": "2026-03-01T11:35:22+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T11:35:22+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -461,7 +460,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Commuters in attesa alla fermata del bus a Lugano, con il lago e le montagne sullo sfondo, simbolo del pendolarismo ticinese."
  },
  "datePublished": "2026-03-01T11:44:50+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T11:44:50+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -490,7 +489,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Bellinzona, Canton Ticino, in una giornata lavorativa, con edifici governativi sullo sfondo che richiamano il dibattito politico."
  },
  "datePublished": "2026-03-01T13:54:26+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T13:54:26+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -519,7 +518,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Veduta notturna del lungolago di Lugano con auto in transito e luci della città riflesse sull'acqua, simbolo del traffico ticinese."
  },
  "datePublished": "2026-03-01T14:55:24+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T14:55:24+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -548,7 +547,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica della regione di Mendrisio, Canton Ticino, al confine con l'Italia, con strade e paesaggi tipici del frontalierato."
  },
  "datePublished": "2026-03-01T16:07:24+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T16:07:24+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -577,7 +576,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Strada panoramica lungo il Lago di Lugano all'alba, con auto che si dirigono verso la frontiera svizzera. Rappresenta il tragitto quotidiano dei frontalieri."
  },
  "datePublished": "2026-03-01T16:37:37+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T16:37:37+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -606,7 +605,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Autostrada A9 tra Chiasso e Como di notte, con chiusure per cantieri e luci di segnalazione accese, traffico di frontalieri."
  },
  "datePublished": "2026-03-01T16:48:27+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T16:48:27+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -635,7 +634,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Una strada di Chiasso con una chiesa storica, persone che camminano, e l'atmosfera di una città di confine nel Mendrisiotto."
  },
  "datePublished": "2026-03-01T18:21:49+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T18:21:49+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -664,7 +663,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Casco da scooter posato su un muretto con vista sul Lago di Lugano all'alba, simbolo del pendolarismo transfrontaliero e della tragedia avvenuta a Porletta."
  },
  "datePublished": "2026-03-01T18:45:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T18:45:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -693,7 +692,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Autostrada A9 vicino al confine italo-svizzero, con luci di auto sfocate di notte, a causa di lavori stradali."
  },
  "datePublished": "2026-03-01T19:09:16+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T19:09:16+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -722,7 +721,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista vivace di Lugano con il lago e le montagne, persone che godono di attività all'aperto."
  },
  "datePublished": "2026-03-01T20:12:40+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T20:12:40+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -751,7 +750,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Auto in coda al valico di frontiera di Brogeda tra Italia e Ticino, con le montagne svizzere sullo sfondo. Simbolo del pendolarismo frontaliero."
  },
  "datePublished": "2026-03-01T20:33:06+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T20:33:06+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -780,7 +779,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Immagine di un'autostrada in entrata vicino a Chiasso al crepuscolo, con auto in movimento e luci sfocate, simbolo dei disagi e dei cantieri sulla A9."
  },
  "datePublished": "2026-03-01T20:47:16+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T20:47:16+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -809,7 +808,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Autostrada A9 tra Chiasso e Como di notte, con luci di auto e traffico sfocate che indicano i lavori in corso al confine italo-svizzero."
  },
  "datePublished": "2026-03-01T21:09:14+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T21:09:14+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -838,7 +837,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Autostrada A9 al confine tra Chiasso e Como di notte, con lavori in corso e luci di cantiere, simbolo dei disagi per i frontalieri."
  },
  "datePublished": "2026-03-01T21:48:11+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T21:48:11+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -867,7 +866,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista di una via trafficata di Lugano, con persone che camminano, simboleggiando il dinamismo del mercato del lavoro ticinese."
  },
  "datePublished": "2026-03-01T22:10:14+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T22:10:14+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -896,7 +895,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista urbana di Lugano, Ticino, con edifici moderni e persone che camminano, simbolo del dinamismo economico e del mercato del lavoro."
  },
  "datePublished": "2026-03-01T22:29:48+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T22:29:48+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -925,7 +924,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Strada tortuosa vicino a Porlezza, con auto e scooter che si dirigono verso il confine, avvolta nella nebbia mattutina. Atmosfera suggestiva del pendolarismo."
  },
  "datePublished": "2026-03-01T22:56:19+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T22:56:19+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -954,7 +953,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del Lago di Lugano e delle montagne circostanti, simbolo della regione di confine tra Italia e Svizzera."
  },
  "datePublished": "2026-03-01T23:18:17+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T23:18:17+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -983,7 +982,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Panorama del lungolago di Lugano con edifici moderni e il Monte San Salvatore, simbolo dell'economia ticinese e delle sue sfide."
  },
  "datePublished": "2026-03-01T23:45:46+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-01T23:45:46+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1012,7 +1011,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Dipendenti di un'azienda moderna in Ticino con vista sulla Lombardia, simbolo di collaborazione transfrontaliera e benessere aziendale."
  },
  "datePublished": "2026-03-02T01:17:57+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T01:17:57+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1041,7 +1040,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Autostrada A9 vicino a Chiasso con traffico pendolare e lavori stradali visibili all'alba o al tramonto."
  },
  "datePublished": "2026-03-02T04:17:25+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T04:17:25+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1070,7 +1069,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con il lago e gli edifici commerciali, simbolo dell'attività economica ticinese in un contesto di rallentamento occupazionale."
  },
  "datePublished": "2026-03-02T05:26:02+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T05:26:02+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1099,7 +1098,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "La frontiera italo-svizzera in un mattino sereno, con un valico di confine e il paesaggio circostante che sfuma all'orizzonte, simbolo delle complesse dinamiche fiscali."
  },
  "datePublished": "2026-03-02T05:54:09+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T05:54:09+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1128,7 +1127,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Un frontaliere consulta i tassi di cambio CHF/EUR sul suo smartphone con il Lago di Lugano sullo sfondo, riflettendo sull'impatto del franco forte."
  },
  "datePublished": "2026-03-02T06:31:44+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T06:31:44+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1157,7 +1156,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Casco da scooter a bordo strada con il Lago di Lugano sullo sfondo, simbolo del tragico incidente di un frontaliere"
  },
  "datePublished": "2026-03-02T06:53:59+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T06:53:59+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1186,7 +1185,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Autostrada A9 vicino a Chiasso all'alba, con lavori notturni e traffico pendolare al confine italo-svizzero."
  },
  "datePublished": "2026-03-02T07:03:43+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T07:03:43+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1215,7 +1214,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano, con il lago e le montagne circostanti, simbolo dell'economia ticinese in cui si discute il salario minimo."
  },
  "datePublished": "2026-03-02T07:29:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T07:29:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1244,7 +1243,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Veduta panoramica del centro di Lugano con il lago e il Monte San Salvatore, che riflette l'economia ticinese e le sue sfide salariali."
  },
  "datePublished": "2026-03-02T07:52:00+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T07:52:00+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1273,7 +1272,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Strada principale di Chiasso con persone che camminano e la torre della chiesa sullo sfondo, simbolo di una comunità in evoluzione."
  },
  "datePublished": "2026-03-02T08:07:09+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T08:07:09+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1302,7 +1301,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Strada costiera nebbiosa lungo il Lago di Lugano, vicino a Porlezza, al mattino presto, con il faro di uno scooter in lontananza."
  },
  "datePublished": "2026-03-02T08:20:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T08:20:07+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1331,7 +1330,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Panorama di Lugano con il lago e le montagne, dove un gruppo di persone discute in primo piano, simbolo delle trattative sul salario minimo in Ticino."
  },
  "datePublished": "2026-03-02T08:32:27+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T08:32:27+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1360,7 +1359,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Veduta del campus di Trevano a Lugano, Ticino, con edifici moderni e aree verdi sotto un cielo azzurro."
  },
  "datePublished": "2026-03-02T09:01:11+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T09:01:11+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1389,7 +1388,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Nuovo sagrato della Chiesa Madonna della Porta a Lavena Ponte Tresa, con vista sul lago di Lugano e l'attività frontaliera."
  },
  "datePublished": "2026-03-02T09:21:13+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T09:21:13+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1418,7 +1417,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Giovane professionista sul lungolago italiano di Lugano, guarda verso la sponda svizzera, riflettendo sulle opportunità di lavoro transfrontaliere."
  },
  "datePublished": "2026-03-02T09:43:02+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T09:43:02+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1447,7 +1446,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Strada cantonale ticinese con segnaletica di velocità, in una zona di confine con montagne e abitazioni sullo sfondo, sotto un cielo mattutino."
  },
  "datePublished": "2026-03-02T10:14:54+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T10:14:54+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1476,7 +1475,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Un autovelox mobile nascosto tra la vegetazione vicino a un valico di frontiera in Ticino, con veicoli in transito."
  },
  "datePublished": "2026-03-02T10:24:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T10:24:07+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1505,7 +1504,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Controlli di frontiera intensificati al valico di Chiasso-Brogeda in Ticino con traffico di frontalieri."
  },
  "datePublished": "2026-03-02T11:11:03+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T11:11:03+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1534,7 +1533,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Lavori di risanamento sulla A13 nel tratto tra Cadenazzo e S. Antonino con cantieri e traffico regolato"
  },
  "datePublished": "2026-03-02T11:30:02+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T11:30:02+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1563,7 +1562,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Castel Grande a Bellinzona, simbolo del potere cantonale in Ticino, con il cielo azzurro."
  },
  "datePublished": "2026-03-02T12:42:37+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T12:42:37+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1592,7 +1591,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Strada cantonale in Ticino con controlli di velocità in corso"
  },
  "datePublished": "2026-03-02T13:02:20+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T13:02:20+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1621,7 +1620,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Cantiere autostradale sulla A13 tra Cadenazzo e Sant'Antonino, Ticino, con luci di segnalazione e veicoli in transito."
  },
  "datePublished": "2026-03-02T13:23:18+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T13:23:18+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1650,7 +1649,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Panorama di Lugano, con il centro finanziario e il lago, simbolo di stabilità economica in Ticino."
  },
  "datePublished": "2026-03-02T15:52:24+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T15:52:24+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1679,7 +1678,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Castel Grande a Bellinzona, simbolo di stabilità e sicurezza nel Canton Ticino."
  },
  "datePublished": "2026-03-02T17:34:53+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T17:34:53+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1708,7 +1707,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Edificio moderno della SUPSI a Mendrisio, centro di formazione tecnica in Ticino."
  },
  "datePublished": "2026-03-02T18:19:47+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T18:19:47+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1737,7 +1736,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Castel Grande a Bellinzona, simbolo del Ticino, con il sole che sorge all'alba, a rappresentare l'inizio di un nuovo ciclo per la polizia cantonale."
  },
  "datePublished": "2026-03-02T18:42:09+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T18:42:09+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1766,7 +1765,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista pittoresca del Lago di Lugano in Ticino."
  },
  "datePublished": "2026-03-02T19:17:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T19:17:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1795,7 +1794,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Nuovi poliziotti a Como, un segno di sicurezza per la comunità."
  },
  "datePublished": "2026-03-02T19:35:31+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T19:35:31+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1824,7 +1823,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Mendrisio, Svizzera, con luci serali e lago calmo, simbolo di sicurezza e vita transfrontaliera."
  },
  "datePublished": "2026-03-02T19:56:10+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T19:56:10+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1853,7 +1852,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Lago di Lugano con ristoranti all'aperto."
  },
  "datePublished": "2026-03-02T20:23:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T20:23:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1882,7 +1881,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano e del suo lago, con le Alpi sullo sfondo, che simboleggia l'opportunità economica del Ticino."
  },
  "datePublished": "2026-03-02T21:09:04+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T21:09:04+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1911,7 +1910,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista spettacolare di Lugano con lago e montagne."
  },
  "datePublished": "2026-03-02T21:37:28+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T21:37:28+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1940,7 +1939,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista pittoresca di Lugano con lago e montagne."
  },
  "datePublished": "2026-03-02T21:59:50+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T21:59:50+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1969,7 +1968,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista di Bellinzona con architettura storica e montagne."
  },
  "datePublished": "2026-03-02T22:16:35+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T22:16:35+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1998,7 +1997,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del Lago di Lugano e il confine italo-svizzero, con un'auto di un frontaliero parcheggiata all'alba."
  },
  "datePublished": "2026-03-02T22:48:09+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T22:48:09+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2027,7 +2026,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con lago e montagne."
  },
  "datePublished": "2026-03-02T23:22:43+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-02T23:22:43+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2057,7 +2056,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Edificio moderno a Lugano con richiami digitali, simbolo dell'innovazione AI transfrontaliera."
  },
  "datePublished": "2026-03-03T04:45:59+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T04:45:59+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2086,7 +2085,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Panoramica di Lugano con il lago, simbolo della resilienza economica ticinese di fronte alle crisi globali."
  },
  "datePublished": "2026-03-03T05:10:59+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T05:10:59+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2115,7 +2114,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Stazione di servizio a Lugano con auto di frontalieri e pendolari, tipica scena ticinese."
  },
  "datePublished": "2026-03-03T05:38:48+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T05:38:48+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2144,7 +2143,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Stazione di servizio in Ticino con vista sulle Alpi all'alba"
  },
  "datePublished": "2026-03-03T06:15:45+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T06:15:45+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2173,7 +2172,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Stazione di servizio nel Ticino al confine italo-svizzero con colonna carburante attiva"
  },
  "datePublished": "2026-03-03T06:26:08+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T06:26:08+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2202,7 +2201,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Veduta panoramica di Lugano con lago e montagne all'alba, Canton Ticino"
  },
  "datePublished": "2026-03-03T06:42:20+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T06:42:20+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2231,7 +2230,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano, con il lago e le montagne sullo sfondo, simbolo dell’economia ticinese"
  },
  "datePublished": "2026-03-03T09:15:24+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T09:15:24+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2260,7 +2259,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vigneti ticinesi con vista sul lago"
  },
  "datePublished": "2026-03-03T10:05:27+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T10:05:27+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2289,7 +2288,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Giocatori di hockey su ghiaccio a Chiasso"
  },
  "datePublished": "2026-03-03T10:45:58+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T10:45:58+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2318,7 +2317,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Svincolo autostradale A2 a Biasca, paesaggio ticinese e traffico"
  },
  "datePublished": "2026-03-03T11:32:33+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T11:32:33+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2347,7 +2346,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano al tramonto con il lago e le montagne."
  },
  "datePublished": "2026-03-03T12:07:44+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T12:07:44+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2376,7 +2375,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Treno regionale a Locarno con pendolari nel contesto montano ticinese"
  },
  "datePublished": "2026-03-03T13:07:32+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T13:07:32+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2405,7 +2404,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Panorama dal Monte Generoso con vista su Ticino e Varese in una giornata limpida"
  },
  "datePublished": "2026-03-03T13:39:09+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T13:39:09+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2434,7 +2433,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con il lago e le montagne circostanti."
  },
  "datePublished": "2026-03-08T17:03:19+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-08T17:03:19+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2463,7 +2462,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Viadotto Brogeda con paesaggio ticinese."
  },
  "datePublished": "2026-03-08T19:05:48+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-08T19:05:48+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2492,7 +2491,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista del Lago di Lugano con montagne sullo sfondo."
  },
  "datePublished": "2026-03-08T21:04:20+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-08T21:04:20+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2521,7 +2520,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista dei castelli di Bellinzona circondati da colline verdi."
  },
  "datePublished": "2026-03-08T21:54:21+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-08T21:54:21+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2550,7 +2549,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista dei castelli di Bellinzona circondati dal paesaggio"
  },
  "datePublished": "2026-03-08T23:01:39+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-08T23:01:39+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2579,7 +2578,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Bellinzona con castelli storici e mercato vivace."
  },
  "datePublished": "2026-03-09T05:29:39+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-09T05:29:39+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2608,7 +2607,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Università della Svizzera italiana (USI) e Scuola universitaria professionale della Svizzera italiana (SUPSI) a Bellinzona."
  },
  "datePublished": "2026-03-09T08:04:18+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-09T08:04:18+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2637,7 +2636,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con le Alpi svizzere sullo sfondo in una giornata limpida"
  },
  "datePublished": "2026-03-09T17:22:58+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-09T17:22:58+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2666,7 +2665,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con montagne sullo sfondo e cielo sereno"
  },
  "datePublished": "2026-03-09T17:41:19+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-09T17:41:19+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2695,7 +2694,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Auto che si rifornisce a Locarno, con vista sulle montagne."
  },
  "datePublished": "2026-03-09T20:02:22+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-09T20:02:22+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2724,7 +2723,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Una donna in piedi su un molo di legno a Gandria, con una vista mozzafiato sul Lago di Lugano."
  },
  "datePublished": "2026-03-09T21:11:13+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-09T21:11:13+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2753,7 +2752,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del Lago di Lugano e delle montagne innevate."
  },
  "datePublished": "2026-03-09T23:08:47+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-09T23:08:47+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2782,7 +2781,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Auto della polizia locale di Lavena Ponte Tresa in azione per fermare i sospettati di furti nei supermercati."
  },
  "datePublished": "2026-03-10T00:03:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-10T00:03:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2811,7 +2810,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Una pattuglia della Polizia Locale fermando un veicolo sospetto a Lavena Ponte Tresa, Ticino."
  },
  "datePublished": "2026-03-10T05:05:56+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-10T05:05:56+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2840,7 +2839,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica dei valichi di confine tra Ticino e Italia, con uffici cantonali sullo sfondo."
  },
  "datePublished": "2026-03-10T07:33:26+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-10T07:33:26+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2869,7 +2868,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Uffici pubblici e valico di Gaggiolo in Ticino, scena urbana realistica"
  },
  "datePublished": "2026-03-10T10:09:52+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-10T10:09:52+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2898,7 +2897,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Incidente stradale a Bioggio con pedone investito sul marciapiede"
  },
  "datePublished": "2026-03-10T12:03:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-10T12:03:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2927,7 +2926,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Tir in colonna al valico di Brogeda con cantieri e disagi al confine italo-svizzero"
  },
  "datePublished": "2026-03-10T17:41:02+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-10T17:41:02+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2956,7 +2955,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Veduta fotorealistica di Bellinzona con i castelli storici, simbolo politico del Ticino"
  },
  "datePublished": "2026-03-10T19:57:37+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-10T19:57:37+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2985,7 +2984,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del lago di Lugano con villaggi e natura circostante in Ticino"
  },
  "datePublished": "2026-03-10T21:07:05+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-10T21:07:05+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3014,7 +3013,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con evento culturale sullo sfondo e le montagne svizzere"
  },
  "datePublished": "2026-03-10T23:02:11+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-10T23:02:11+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3043,7 +3042,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Veduta panoramica di Lugano con le Alpi sullo sfondo in una giornata limpida di primavera."
  },
  "datePublished": "2026-03-10T23:57:24+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-10T23:57:24+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3072,7 +3071,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Fabbriche di armamenti svizzere con operai al lavoro, vista aerea di Bellinzona."
  },
  "datePublished": "2026-03-11T05:06:52+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-11T05:06:52+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3101,7 +3100,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista di Lugano con auto in movimento"
  },
  "datePublished": "2026-03-11T08:08:50+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-11T08:08:50+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3130,7 +3129,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Una scena di vita quotidiana a Lugano con mezzi pubblici"
  },
  "datePublished": "2026-03-11T10:16:30+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-11T10:16:30+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3159,7 +3158,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Lavoratori in un'azienda di Como"
  },
  "datePublished": "2026-03-11T12:16:45+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-11T12:16:45+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3188,7 +3187,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Coda di traffico sull'A2 presso Giornico con segnaletica di cantiere e montagne ticinesi"
  },
  "datePublished": "2026-03-11T14:56:52+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-11T14:56:52+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3217,7 +3216,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Camion elettrici e tradizionali sulla strada nel Canton Ticino"
  },
  "datePublished": "2026-03-11T17:48:13+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-11T17:48:13+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3246,7 +3245,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Camion e auto sulla strada con lago di Lugano sullo sfondo"
  },
  "datePublished": "2026-03-11T20:01:10+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-11T20:01:10+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3275,7 +3274,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Treno in ritardo alla stazione di Lugano"
  },
  "datePublished": "2026-03-11T21:10:14+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-11T21:10:14+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3304,7 +3303,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Auto con persone che condividono un viaggio in Ticino"
  },
  "datePublished": "2026-03-11T23:00:52+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-11T23:00:52+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3333,7 +3332,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Centrale elettrica a Lugano, Ticino"
  },
  "datePublished": "2026-03-11T23:59:02+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-11T23:59:02+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3362,7 +3361,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Apprendisti frontalieri al valico di Locarno, con sfondo montano e traffico di passanti"
  },
  "datePublished": "2026-03-12T05:10:57+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-12T05:10:57+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3391,7 +3390,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista del Lago di Lugano con montagne sullo sfondo."
  },
  "datePublished": "2026-03-12T08:15:36+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-12T08:15:36+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3420,7 +3419,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Ambiente vivace a Chiasso, luogo di incontro per migranti."
  },
  "datePublished": "2026-03-12T10:24:00+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-12T10:24:00+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3449,7 +3448,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Fila all'ufficio postale di Chiasso"
  },
  "datePublished": "2026-03-12T17:43:54+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-12T17:43:54+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3478,7 +3477,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Il Castel Grande di Bellinzona, un'imponente fortezza medievale che domina la città."
  },
  "datePublished": "2026-03-12T20:04:30+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-12T20:04:30+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3507,7 +3506,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Il Cinema Teatro di Chiasso, sede del festival jazz, illuminato di notte."
  },
  "datePublished": "2026-03-12T21:11:40+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-12T21:11:40+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3536,7 +3535,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Apprendista cuoco con permesso di lavoro G"
  },
  "datePublished": "2026-03-12T23:06:54+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-12T23:06:54+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3565,7 +3564,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista aerea di Chiasso, con il confine e il traffico in primo piano."
  },
  "datePublished": "2026-03-12T23:58:37+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-12T23:58:37+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3594,7 +3593,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Veduta del Castelgrande di Bellinzona, simbolo storico del Ticino, durante una giornata di sole."
  },
  "datePublished": "2026-03-13T05:09:19+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-13T05:09:19+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3623,7 +3622,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista di Lugano con il lago"
  },
  "datePublished": "2026-03-13T08:07:04+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-13T08:07:04+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3652,7 +3651,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Polizia locale a Lavena Ponte Tresa"
  },
  "datePublished": "2026-03-13T10:07:51+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-13T10:07:51+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3682,7 +3681,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Apertura della pesca in Ticino"
  },
  "datePublished": "2026-03-13T14:35:03+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-13T14:35:03+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3711,7 +3710,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "La franchigia minima dell'assicurazione malattia potrebbe aumentare da 300 a 400 franchi."
  },
  "datePublished": "2026-03-13T17:44:42+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-13T17:44:42+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3740,7 +3739,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Incidente stradale nel tunnel di Trin"
  },
  "datePublished": "2026-03-13T20:31:24+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-13T20:31:24+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3769,7 +3768,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Chiasso, aree verdi e panorama sereno"
  },
  "datePublished": "2026-03-13T21:29:50+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-13T21:29:50+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3798,7 +3797,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Comitati e associazioni intorno a Malpensa chiedono l'assemblea del CUV per il 2026"
  },
  "datePublished": "2026-03-13T22:26:58+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-13T22:26:58+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3827,7 +3826,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Operatore di borsa sul fiume Toce a Locarno"
  },
  "datePublished": "2026-03-13T23:25:47+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-13T23:25:47+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3856,7 +3855,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del Lago di Lugano con valico di frontiera e traffico in Ticino"
  },
  "datePublished": "2026-03-14T01:25:04+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T01:25:04+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3885,7 +3884,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Palazzi istituzionali e uffici a Bellinzona, Ticino, scena realistica"
  },
  "datePublished": "2026-03-14T04:10:54+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T04:10:54+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3914,7 +3913,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Centro raccolta rifiuti a Locarno, dove vengono smontate batterie da dispositivi elettronici."
  },
  "datePublished": "2026-03-14T05:50:27+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T05:50:27+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3943,7 +3942,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Veduta fotorealistica di Bellinzona con i tre castelli e il centro storico in una giornata di primavera luminosa"
  },
  "datePublished": "2026-03-14T06:42:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T06:42:07+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3972,7 +3971,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica della città di Lugano con edifici residenziali e colline sullo sfondo in Ticino"
  },
  "datePublished": "2026-03-14T07:35:43+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T07:35:43+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4001,7 +4000,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con lago e montagne sullo sfondo in giornata primaverile luminosa"
  },
  "datePublished": "2026-03-14T08:31:53+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T08:31:53+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4030,7 +4029,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Valico di Brogeda tra Italia e Ticino con frontalieri e veicoli in transito durante una giornata lavorativa."
  },
  "datePublished": "2026-03-14T09:31:01+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T09:31:01+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4059,7 +4058,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Stazione di servizio affollata vicino al confine italo-svizzero in Ticino con auto e montagne sullo sfondo"
  },
  "datePublished": "2026-03-14T10:25:32+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T10:25:32+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4088,7 +4087,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "una foto di un valico di frontiera tra Italia e Svizzera"
  },
  "datePublished": "2026-03-14T11:39:29+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T11:39:29+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4117,7 +4116,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Max 125 chars"
  },
  "datePublished": "2026-03-14T17:34:47+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T17:34:47+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4146,7 +4145,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Lavena Ponte Tresa"
  },
  "datePublished": "2026-03-14T18:31:29+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T18:31:29+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4175,7 +4174,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Lugano vista dal lago"
  },
  "datePublished": "2026-03-14T19:25:28+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T19:25:28+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4204,7 +4203,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Locarno, Ticino"
  },
  "datePublished": "2026-03-14T20:24:20+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T20:24:20+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4233,7 +4232,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Panorama di Bellinzona con il Lago di Lugano"
  },
  "datePublished": "2026-03-14T21:24:38+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T21:24:38+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4262,7 +4261,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Strada della Val Bedretto a Bellinzona"
  },
  "datePublished": "2026-03-14T22:23:51+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T22:23:51+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4291,7 +4290,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Mendrisio con ristoranti e persone partecipanti al concorso passaporti di fedeltà"
  },
  "datePublished": "2026-03-14T23:24:29+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-14T23:24:29+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4320,7 +4319,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista fotorealistica del confine italo-svizzero a Chiasso con autostrada e traffico verso il Ticino"
  },
  "datePublished": "2026-03-15T04:31:21+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T04:31:21+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4349,7 +4348,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Miniera d'Oro di Sessa a Swissminiatur, Ticino"
  },
  "datePublished": "2026-03-15T06:18:06+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T06:18:06+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4378,7 +4377,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con il lago"
  },
  "datePublished": "2026-03-15T07:50:20+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T07:50:20+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4407,7 +4406,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Valle innevata in Ticino con neve fresca"
  },
  "datePublished": "2026-03-15T09:51:02+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T09:51:02+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4436,7 +4435,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista di Bellinzona con il suo castello e montagne sullo sfondo."
  },
  "datePublished": "2026-03-15T11:25:53+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T11:25:53+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4465,7 +4464,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Vista di Bellinzona con i suoi castelli storici e montagne circostanti."
  },
  "datePublished": "2026-03-15T12:41:17+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T12:41:17+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4494,7 +4493,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Paesaggio invernale in Ticino con montagne innevate."
  },
  "datePublished": "2026-03-15T14:32:27+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T14:32:27+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4523,7 +4522,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Castelli di Bellinzona immersi nel verde con cielo blu."
  },
  "datePublished": "2026-03-15T15:29:43+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T15:29:43+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4552,7 +4551,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Campo da calcio urbano a Como con binari ferroviari sullo sfondo"
  },
  "datePublished": "2026-03-15T16:48:29+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T16:48:29+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4581,7 +4580,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "La nuova miniera d'oro a Swissminiatur a Melide nel Canton Ticino"
  },
  "datePublished": "2026-03-15T17:40:16+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T17:40:16+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4610,7 +4609,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Panorama di Lugano con il lago e le montagne sullo sfondo al tramonto"
  },
  "datePublished": "2026-03-15T18:59:29+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T18:59:29+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4639,7 +4638,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Treno pendolare sul lago di Lugano al tramonto con vista sulle montagne"
  },
  "datePublished": "2026-03-15T19:50:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T19:50:07+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4664,7 +4663,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "description": "Come ottimizzare il cambio franco-euro: confronto tra banche, fintech e broker, strategie di cambio frazionato e impatto fiscale.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/lugano-view.webp`, "width": 1344, "height": 756, "caption": "Banconote in franchi svizzeri e euro su una scrivania con calcolatrice e grafici di cambio valuta" },
  "datePublished": "2026-03-15T20:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T20:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -4689,7 +4688,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "description": "Guida completa alla pensione per chi lavora in Svizzera: tre pilastri, totalizzazione Italia-Svizzera e simulazione della rendita.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/bellinzona.webp`, "width": 1344, "height": 756, "caption": "Coppia di pensionati che passeggia lungo il lago di Lugano con le Alpi sullo sfondo" },
  "datePublished": "2026-03-15T20:01:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T20:01:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pensione",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -4714,7 +4713,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "description": "Permesso B o Permesso G? Confronto dettagliato su costi, tasse, sanità, qualità della vita con esempi pratici 2026.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/locarno.webp`, "width": 1344, "height": 756, "caption": "Vista panoramica del confine italo-svizzero con il lago di Lugano e i tetti di un villaggio italiano" },
  "datePublished": "2026-03-15T20:02:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T20:02:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -4739,7 +4738,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "description": "Guida ai diritti del lavoratore frontaliere contro il dumping salariale: forme più comuni, a chi rivolgersi e procedure legali.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/mendrisio.webp`, "width": 1344, "height": 756, "caption": "Operai su un cantiere edile in Ticino con elmetti di sicurezza e documentazione contrattuale" },
  "datePublished": "2026-03-15T20:03:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T20:03:00+01:00",
  "inLanguage": "it",
  "articleSection": "Fiscale",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -4764,7 +4763,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "description": "Tutto sulla copertura sanitaria del frontaliere: LAMal vs CMI, indennità giornaliere, protezione dal licenziamento e malattie rare.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/castelgrande.webp`, "width": 1344, "height": 756, "caption": "Medico in camice bianco in un ospedale svizzero che consulta documenti con un paziente" },
  "datePublished": "2026-03-15T20:04:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T20:04:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -4789,7 +4788,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "description": "Panoramica completa dei calcolatori e comparatori gratuiti per frontalieri: stipendio, cambio, assicurazione, pensione e lavoro.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/lugano-view.webp`, "width": 1344, "height": 756, "caption": "Schermo di computer con grafici finanziari e calcolatrice in un ufficio moderno con vista sulle montagne" },
  "datePublished": "2026-03-15T20:05:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T20:05:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -4819,7 +4818,7 @@ const BLOG_SEO_METADATA_2: Record<string, SEOMetadata> = {
  "caption": "Stazione di servizio in Ticino con prezzi carburante elevati, auto in rifornimento, montagne sullo sfondo"
  },
  "datePublished": "2026-03-15T20:50:49+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-15T20:50:49+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},

--- a/services/seo/seo-blog-3.ts
+++ b/services/seo/seo-blog-3.ts
@@ -4,7 +4,6 @@
 import type { SEOMetadata } from '../seoService';
 
 const BASE_URL = 'https://frontaliereticino.ch';
-const BUILD_DATE_ISO = new Date().toISOString();
 
 const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  'blog-acquarossa-nuovo-polo-filovia-2026': {
@@ -1864,7 +1863,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  "caption": "Cross-border worker calculator comparison"
  },
  "datePublished": "2026-03-31T10:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-31T10:00:00+01:00",
  "inLanguage": "en",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1890,7 +1889,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  "description": "Analisi completa dei pro e contro del permesso G per frontalieri: tassazione, previdenza AVS/LPP, diritti lavorativi, e quando conviene rispetto al permesso B.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/mendrisio.webp`, "width": 1200, "height": 675 },
  "datePublished": "2026-04-03",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-03",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1926,7 +1925,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  "description": "Guida alla scelta tra assicurazione sanitaria svizzera LAMal e SSN italiano per frontalieri: costi, coperture e scenari concreti.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/lac-lugano.webp`, "width": 1200, "height": 675 },
  "datePublished": "2026-04-03",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-03",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1962,7 +1961,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  "description": "Portali di ricerca, settori che assumono, CV svizzero, colloquio e stipendi medi: guida completa per trovare lavoro in Canton Ticino.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/lugano-view.webp`, "width": 1200, "height": 675 },
  "datePublished": "2026-04-03",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-03",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1998,7 +1997,7 @@ const BLOG_SEO_METADATA_3: Record<string, SEOMetadata> = {
  "description": "Dalla ricerca del lavoro al primo giorno: permessi, tasse, previdenza, assicurazione e tutto quello che serve per lavorare in Svizzera dall\'Italia.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/castelgrande.webp`, "width": 1200, "height": 675 },
  "datePublished": "2026-04-03",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-03",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},

--- a/services/seo/seo-blog-4.ts
+++ b/services/seo/seo-blog-4.ts
@@ -4,7 +4,6 @@
 import type { SEOMetadata } from '../seoService';
 
 const BASE_URL = 'https://frontaliereticino.ch';
-const BUILD_DATE_ISO = new Date().toISOString();
 
 const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  'blog-walter-bonatti-in-capo-al-mondo': {
@@ -83,7 +82,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Polizia svizzera blocca due teenager nel Canton Sankt Gallen, scena urbana di Sargans."
  },
  "datePublished": "2026-03-18T07:12:46+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-18T07:12:46+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -112,7 +111,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Ufficio moderno in Ticino con vista sul lago e montagna"
  },
  "datePublished": "2026-03-18T10:06:52+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-18T10:06:52+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -141,7 +140,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Cabinovia in Ticino con vento forte e nuvole in cielo"
  },
  "datePublished": "2026-03-18T15:12:29+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-18T15:12:29+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -170,7 +169,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Lago di Lugano, confine italo-svizzero"
  },
  "datePublished": "2026-03-18T20:58:59+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-18T20:58:59+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -199,7 +198,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Stazione ferroviaria di Locarno"
  },
  "datePublished": "2026-03-18T21:50:39+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-18T21:50:39+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -228,7 +227,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Arrestato un sospettato di truffa a Bellinzona"
  },
  "datePublished": "2026-03-18T22:48:22+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-18T22:48:22+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -257,7 +256,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Parco pubblico a Lugano"
  },
  "datePublished": "2026-03-18T23:45:16+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-18T23:45:16+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -286,7 +285,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Buffet di Camedo, Ticino, pronto ad ospitare eventi"
  },
  "datePublished": "2026-03-19T06:08:27+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T06:08:27+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -315,7 +314,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Riunione di lavoro a Berna con focus su documenti e strategie economiche."
  },
  "datePublished": "2026-03-19T07:11:48+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T07:11:48+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -344,7 +343,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Delegazione ticinese a Coira per discutere di criminalità organizzata"
  },
  "datePublished": "2026-03-19T08:11:13+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T08:11:13+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -373,7 +372,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Annunci di lavoro con salari da dumping segnalati nel Mendrisiotto, caso finisce in governo cantonale."
  },
  "datePublished": "2026-03-19T09:31:19+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T09:31:19+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -402,7 +401,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Cantiere edile in Canton Ticino, controlli regolari e sicurezza garantita"
  },
  "datePublished": "2026-03-19T10:12:32+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T10:12:32+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -431,7 +430,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del Lago di Lugano su un giorno soleggiato, con le montagne sullo sfondo."
  },
  "datePublished": "2026-03-19T11:28:32+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T11:28:32+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -460,7 +459,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista del Lago Maggiore e del Castello Visconteo a Locarno."
  },
  "datePublished": "2026-03-19T12:13:35+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T12:13:35+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -489,7 +488,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Mendrisio, una città di confine nel Canton Ticino, con le montagne sullo sfondo."
  },
  "datePublished": "2026-03-19T13:18:43+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T13:18:43+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -518,7 +517,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Locarno con il Lago Maggiore e il Monte Verità."
  },
  "datePublished": "2026-03-19T14:35:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T14:35:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -547,7 +546,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del Lago di Lugano con il borgo di Gandria."
  },
  "datePublished": "2026-03-19T15:23:24+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T15:23:24+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -577,7 +576,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Una delegazione ticinese si incontra a Berna per discutere la rappresentanza degli italofoni nell'Amministrazione federale."
  },
  "datePublished": "2026-03-19T17:52:19+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T17:52:19+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -606,7 +605,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Persona che guarda il lago Lugano da un punto di vista panoramico"
  },
  "datePublished": "2026-03-19T19:06:05+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T19:06:05+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -635,7 +634,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Veicolo in transito al confine italo-svizzero"
  },
  "datePublished": "2026-03-19T19:51:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T19:51:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -664,7 +663,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Un incidente stradale sulla strada del lago in Varese"
  },
  "datePublished": "2026-03-19T21:11:01+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T21:11:01+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -693,7 +692,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Una panoramica fotografica di Lugano con il Lago di Lugano in primo piano, scattata in una giornata soleggiata a mezzogiorno."
  },
  "datePublished": "2026-03-19T21:46:55+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T21:46:55+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -722,7 +721,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "La Giustizia in Ticino: bilico e futuro incerto"
  },
  "datePublished": "2026-03-19T23:03:50+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T23:03:50+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -751,7 +750,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Immagine un parco eolico in Ticino con turbine che ruotano lentamente nel vento al tramonto"
  },
  "datePublished": "2026-03-19T23:41:40+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-19T23:41:40+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -780,7 +779,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista aerea del passo del San Gottardo con eolico nel fondo, scattata con una fotocamera DSLR in Ticino, Svizzera."
  },
  "datePublished": "2026-03-20T02:46:46+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T02:46:46+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -809,7 +808,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Contrabbando ai confini"
  },
  "datePublished": "2026-03-20T03:22:57+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T03:22:57+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -838,7 +837,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Uffici pubblici in Ticino con valico di frontiera, scena realistica"
  },
  "datePublished": "2026-03-20T06:02:30+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T06:02:30+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -867,7 +866,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Veduta di Bellinzona con scenario di montagne e città, rappresentativa del Canton Ticino."
  },
  "datePublished": "2026-03-20T06:36:45+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T06:36:45+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -896,7 +895,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Cantiere UBS a Bellinzona, operai al lavoro con skyline della città sullo sfondo"
  },
  "datePublished": "2026-03-20T07:09:05+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T07:09:05+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -925,7 +924,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Uffici cantonali a Bellinzona con valico di Brogeda e attività lavorative in primo piano"
  },
  "datePublished": "2026-03-20T07:34:50+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T07:34:50+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -954,7 +953,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Valico di Gaggiolo con strutture dedicate ai migranti in Ticino, scena di frontiera svizzero-italiana."
  },
  "datePublished": "2026-03-20T07:56:20+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T07:56:20+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -983,7 +982,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista del Lago Maggiore e delle montagne del Ticino con città di Locarno sullo sfondo"
  },
  "datePublished": "2026-03-20T08:08:37+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T08:08:37+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1012,7 +1011,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Ufficio sanitario ticinese con tecnologia avanzata al confine Italia-Svizzera"
  },
  "datePublished": "2026-03-20T08:54:54+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T08:54:54+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1041,7 +1040,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista di Bellinzona con edifici governativi e paesaggio alpino in lontananza."
  },
  "datePublished": "2026-03-20T09:13:04+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T09:13:04+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1070,7 +1069,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Auto al valico di Gaggiolo con telecamere di sicurezza in Ticino"
  },
  "datePublished": "2026-03-20T09:55:23+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T09:55:23+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1099,7 +1098,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Frontiera Ticino-Italia con frontaliere al valico di Brogeda, scenario naturale e urbano."
  },
  "datePublished": "2026-03-20T10:11:17+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T10:11:17+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1128,7 +1127,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Scuola secondaria superiore a Locarno con studenti e insegnanti all'aperto"
  },
  "datePublished": "2026-03-20T10:52:35+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T10:52:35+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1157,7 +1156,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Valico di frontiera in Ticino con controllo transito e paesaggio montano"
  },
  "datePublished": "2026-03-20T11:11:29+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T11:11:29+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1186,7 +1185,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Frontalieri ticinesi al valico di Brogeda, lavoro e integrazione sociale"
  },
  "datePublished": "2026-03-20T11:42:04+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T11:42:04+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1215,7 +1214,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Valico di confine Ticino con traffico tra Italia e Svizzera, scena di frontaliers e paesaggio alpino."
  },
  "datePublished": "2026-03-20T13:19:14+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T13:19:14+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1244,7 +1243,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Auto in transito al valico di Gaggiolo con montagne sullo sfondo in Ticino"
  },
  "datePublished": "2026-03-20T13:49:13+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T13:49:13+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1273,7 +1272,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Valle alpina in Ticino con cielo nuvoloso e foresta, scena realistica DSLR."
  },
  "datePublished": "2026-03-20T14:55:43+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T14:55:43+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1302,7 +1301,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Panorama di Bellinzona con le Tre Torri e il cielo azzurro"
  },
  "datePublished": "2026-03-20T15:29:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T15:29:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1331,7 +1330,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Valico di confine tra Italia e Svizzera con auto in transito."
  },
  "datePublished": "2026-03-20T15:59:53+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T15:59:53+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1360,7 +1359,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Cantieri edilizi nel Mendrisiotto, operai al lavoro e strutture in costruzione."
  },
  "datePublished": "2026-03-20T16:14:46+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T16:14:46+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1389,7 +1388,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Famiglia felice con bambini a passeggio nel parco di Lugano"
  },
  "datePublished": "2026-03-20T17:04:05+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T17:04:05+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1418,7 +1417,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Linea ferroviaria Centovallina-Vigezzina, Ticino"
  },
  "datePublished": "2026-03-20T17:31:42+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T17:31:42+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1447,7 +1446,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Piscina comunale a Porrentruy, Svizzera"
  },
  "datePublished": "2026-03-20T17:50:17+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T17:50:17+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1476,7 +1475,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Centro congressi Ville Ponti a Varese"
  },
  "datePublished": "2026-03-20T18:15:00+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T18:15:00+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1505,7 +1504,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Parco eolico a San Gottardo"
  },
  "datePublished": "2026-03-20T19:20:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T19:20:07+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1534,7 +1533,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Cure a domicilio in Ticino"
  },
  "datePublished": "2026-03-20T21:04:34+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T21:04:34+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1563,7 +1562,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Campo detriti nubifragio Grigioni Ticino"
  },
  "datePublished": "2026-03-20T21:58:42+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T21:58:42+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1592,7 +1591,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Una scena di una autostrada affollata nel Ticino, Svizzera, con automobili e camion in transito e pochi pedoni che camminano sulla banchina."
  },
  "datePublished": "2026-03-20T22:58:17+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-20T22:58:17+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1621,7 +1620,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Immagini di un lago con una nave in movimento, con il profilo di una città sullo sfondo"
  },
  "datePublished": "2026-03-21T03:13:32+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T03:13:32+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1650,7 +1649,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Bellinzona con castelli storici."
  },
  "datePublished": "2026-03-21T04:49:46+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T04:49:46+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1679,7 +1678,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Il tramonto sulla riva del lago Lugano, con la città di Lugano sullo sfondo"
  },
  "datePublished": "2026-03-21T05:52:27+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T05:52:27+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1708,7 +1707,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Un automobilista attraversa il valico di Brogeda"
  },
  "datePublished": "2026-03-21T06:12:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T06:12:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1737,7 +1736,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Il franco svizzero a valori record sta rendendo più ricchi i frontalieri, ma un annuncio della Banca Nazionale Svizzera potrebbe cambiare tutto."
  },
  "datePublished": "2026-03-21T07:02:06+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T07:02:06+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1766,7 +1765,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "I tagli alle accise stanno mettendo sotto pressione i distributori di carburante in Ticino."
  },
  "datePublished": "2026-03-21T07:27:46+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T07:27:46+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1795,7 +1794,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Una scena dei laboratori farmaceutici in Ticino"
  },
  "datePublished": "2026-03-21T07:40:32+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T07:40:32+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1824,7 +1823,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Cantiere moderno a Mendrisio, Ticino, con operai al lavoro."
  },
  "datePublished": "2026-03-21T08:02:26+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T08:02:26+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1853,7 +1852,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista di Lugano, città svizzera con lago e montagne."
  },
  "datePublished": "2026-03-21T08:47:56+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T08:47:56+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1882,7 +1881,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Bellinzona e dei suoi castelli."
  },
  "datePublished": "2026-03-21T09:07:48+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T09:07:48+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1911,7 +1910,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista del Lago di Lugano con negozi di cioccolato."
  },
  "datePublished": "2026-03-21T09:45:15+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T09:45:15+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1941,7 +1940,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Stazione di servizio in Ticino con prezzi del diesel."
  },
  "datePublished": "2026-03-21T10:03:22+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T10:03:22+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1981,7 +1980,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Conferenza sulla sanità a Varese con iniziative di welfare."
  },
  "datePublished": "2026-03-21T10:40:36+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T10:40:36+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2010,7 +2009,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista del Lago di Lugano con montagne circostanti."
  },
  "datePublished": "2026-03-21T11:01:59+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T11:01:59+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2039,7 +2038,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Scena scolastica a Lugano con studenti impegnati nell'apprendimento."
  },
  "datePublished": "2026-03-21T11:44:36+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T11:44:36+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2068,7 +2067,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del Lago di Lugano con barche."
  },
  "datePublished": "2026-03-21T13:09:21+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T13:09:21+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2097,7 +2096,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con lago e montagne."
  },
  "datePublished": "2026-03-21T13:38:10+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T13:38:10+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2126,7 +2125,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con montagne sullo sfondo."
  },
  "datePublished": "2026-03-21T13:54:29+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T13:54:29+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2155,7 +2154,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Ragazzi in aula senza cellulari, ambiente scolastico Ticino."
  },
  "datePublished": "2026-03-21T14:48:58+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T14:48:58+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2184,7 +2183,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Bellinzona con vista sul castello e montagne circostanti."
  },
  "datePublished": "2026-03-21T15:10:47+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T15:10:47+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2213,7 +2212,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Il colonnello SMG Stefano Trojani"
  },
  "datePublished": "2026-03-21T15:43:34+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T15:43:34+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2242,7 +2241,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Funivia di Monteviasco che attraversa la Val Veddasca, offrendo viste panoramiche sulle Alpi."
  },
  "datePublished": "2026-03-21T16:13:56+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T16:13:56+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2271,7 +2270,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Veduta panoramica della città di Lugano con il lago e le montagne sullo sfondo, simbolo del Ticino attrattivo per ricchi e investitori"
  },
  "datePublished": "2026-03-21T16:41:51+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T16:41:51+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2300,7 +2299,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Aula scolastica in Ticino senza cellulari, studenti concentrati durante la lezione"
  },
  "datePublished": "2026-03-21T17:01:21+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T17:01:21+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2329,7 +2328,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Imbarcazione della Società Navigazione Lago sul Lago di Lugano con vista delle montagne e del lungolago di Lugano."
  },
  "datePublished": "2026-03-21T17:36:16+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T17:36:16+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2358,7 +2357,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Veduta panoramica di Lugano con il lago e le montagne sullo sfondo in una giornata limpida"
  },
  "datePublished": "2026-03-21T17:56:57+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-21T17:56:57+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2387,7 +2386,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Paesaggio montano e villaggi della Valle Calanca in Ticino"
  },
  "datePublished": "2026-03-26T03:22:49+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-26T03:22:49+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2416,7 +2415,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista della città di Lugano"
  },
  "datePublished": "2026-03-26T07:27:47+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-26T07:27:47+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2445,7 +2444,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Comune di Lavena Ponte Tresa al confine con la Svizzera che si impegna per la pulizia e il verde."
  },
  "datePublished": "2026-03-26T13:53:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-26T13:53:07+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2474,7 +2473,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "gruppo di persone in disaccordo in un'aula, con una bandiera svizzera sullo sfondo"
  },
  "datePublished": "2026-03-26T19:24:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-26T19:24:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2503,7 +2502,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Aula scolastica moderna in Ticino con studenti e lavagne digitali"
  },
  "datePublished": "2026-03-27T03:25:32+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-27T03:25:32+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2532,7 +2531,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Bicicletta elettrica abbandonata a Lugano"
  },
  "datePublished": "2026-03-27T07:23:58+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-27T07:23:58+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2561,7 +2560,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "L'orologio delle valute di Lugano"
  },
  "datePublished": "2026-03-27T10:06:30+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-27T10:06:30+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2590,7 +2589,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Stazione di servizio a Lugano"
  },
  "datePublished": "2026-03-27T13:48:53+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-27T13:48:53+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2619,7 +2618,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Panoramica della Locarno"
  },
  "datePublished": "2026-03-27T16:02:39+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-27T16:02:39+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2648,7 +2647,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Vista mattutina di Lugano con una mamma e il passeggino sul lungolago"
  },
  "datePublished": "2026-03-27T19:09:09+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-27T19:09:09+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2677,7 +2676,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Municipio di Chiasso al tramonto"
  },
  "datePublished": "2026-03-27T21:49:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-27T21:49:07+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2706,7 +2705,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Villa Andrea a Varese, sede del Congresso Svizzera‑Italia 2026, al tramonto con vista sul confine italo‑svizzero."
  },
  "datePublished": "2026-03-28T02:56:51+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-28T02:56:51+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2735,7 +2734,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Tribunale penale di Mendrisio all'alba, bandiera svizzera che sventola"
  },
  "datePublished": "2026-03-28T05:03:13+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-28T05:03:13+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2764,7 +2763,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Panoramica del lago di Lugano con la città di Lugano."
  },
  "datePublished": "2026-03-28T07:12:30+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-28T07:12:30+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2793,7 +2792,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Camminatore sulla Via Francisca del Lucomagno"
  },
  "datePublished": "2026-03-28T09:50:39+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-28T09:50:39+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2822,7 +2821,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Foto di un valico montano in Ticino con una strada secondaria scura e tortuosa"
  },
  "datePublished": "2026-03-28T15:41:57+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-28T15:41:57+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2851,7 +2850,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "La polizia indaga sulla rissa notturna a Lavena Ponte Tresa"
  },
  "datePublished": "2026-03-28T21:46:20+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-28T21:46:20+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2880,7 +2879,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Scuola elementare di Magliaso durante l'ora di attività all'aperto"
  },
  "datePublished": "2026-03-29T03:33:28+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-29T03:33:28+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2909,7 +2908,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Un uomo riceve un premio di cassa malati a Lugano"
  },
  "datePublished": "2026-03-29T07:20:23+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-29T07:20:23+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2938,7 +2937,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Ponte Tresa dopo una rissa"
  },
  "datePublished": "2026-03-29T09:51:18+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-29T09:51:18+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2967,7 +2966,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Confine di Chiasso con traffico intenso durante le ore di punta"
  },
  "datePublished": "2026-03-29T13:24:43+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-29T13:24:43+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2996,7 +2995,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Coda di auto al tunnel del San Gottardo"
  },
  "datePublished": "2026-03-29T15:45:09+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-29T15:45:09+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3025,7 +3024,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Due persone discutono in un ufficio governativo. Locarno, Ticino."
  },
  "datePublished": "2026-03-29T19:06:41+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-29T19:06:41+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3054,7 +3053,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Persona che indossa occhiali intelligenti TAMI a Lugano con vista sul lago"
  },
  "datePublished": "2026-03-29T21:49:32+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-29T21:49:32+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3083,7 +3082,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Fotografia di un valico svizzero a mezzogiorno"
  },
  "datePublished": "2026-03-30T03:33:59+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-30T03:33:59+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3112,7 +3111,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Immagine di un valico di frontiera in Ticino"
  },
  "datePublished": "2026-03-30T10:31:31+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-30T10:31:31+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3141,7 +3140,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Stazione ferroviaria di Lugano con un treno TILO"
  },
  "datePublished": "2026-03-30T13:56:29+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-30T13:56:29+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3170,7 +3169,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Scuola elementare a Chiasso"
  },
  "datePublished": "2026-03-30T16:13:03+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-30T16:13:03+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3199,7 +3198,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Lavoratori a Leonardo Cascina Costa in Ticino in protesta contro il cambio di gestione"
  },
  "datePublished": "2026-03-30T19:15:02+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-30T19:15:02+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3228,7 +3227,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Bambino che mangia in scuola dell'infanzia a Mendrisio, Ticino."
  },
  "datePublished": "2026-03-30T21:53:29+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-30T21:53:29+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3257,7 +3256,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Rappresentanza del settore ICT nel contesto di un ufficio cantonale in Ticino"
  },
  "datePublished": "2026-03-31T03:25:42+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-31T03:25:42+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -3286,7 +3285,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Cittadino italiano fermato al valico di Ponte Chiasso con 7 kg di rare monete d'argento nascoste nel bagagliaio di una Ford Mustang"
  },
  "datePublished": "2026-03-31T07:46:01+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-31T07:46:01+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5199,7 +5198,7 @@ const BLOG_SEO_METADATA_4: Record<string, SEOMetadata> = {
  "caption": "Benzinaio in aumento dei prezzi dei carburanti in Ticino"
  },
  "datePublished": "2026-04-07T09:55:25+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-07T09:55:25+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},

--- a/services/seo/seo-blog-5.ts
+++ b/services/seo/seo-blog-5.ts
@@ -4,7 +4,6 @@
 import type { SEOMetadata } from '../seoService';
 
 const BASE_URL = 'https://frontaliereticino.ch';
-const BUILD_DATE_ISO = new Date().toISOString();
 
 const BLOG_SEO_METADATA_5: Record<string, SEOMetadata> = {
   'blog-spese-bancarie-titoli-frontalieri': {

--- a/services/seo/seo-blog-6.ts
+++ b/services/seo/seo-blog-6.ts
@@ -4,7 +4,6 @@
 import type { SEOMetadata } from '../seoService';
 
 const BASE_URL = 'https://frontaliereticino.ch';
-const BUILD_DATE_ISO = new Date().toISOString();
 
 const BLOG_SEO_METADATA_6: Record<string, SEOMetadata> = {
   'blog-risoluzione-federviti-vino-ticinese-2025': {

--- a/services/seo/seo-blog-7.ts
+++ b/services/seo/seo-blog-7.ts
@@ -4,7 +4,6 @@
 import type { SEOMetadata } from '../seoService';
 
 const BASE_URL = 'https://frontaliereticino.ch';
-const BUILD_DATE_ISO = new Date().toISOString();
 
 const BLOG_SEO_METADATA_7: Record<string, SEOMetadata> = {
   'blog-education-day-confindustria-varese-2026': {

--- a/services/seo/seo-blog-ch.ts
+++ b/services/seo/seo-blog-ch.ts
@@ -7,7 +7,6 @@
 import type { SEOMetadata } from '../seoService';
 
 const BASE_URL = 'https://frontaliereticino.ch';
-const BUILD_DATE_ISO = new Date().toISOString();
 
 const BLOG_CH_SEO_METADATA: Record<string, SEOMetadata> = {
  'blog-costo-vita-svizzera-2026': {
@@ -24,7 +23,7 @@ const BLOG_CH_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "Confronto tra i cantoni svizzeri su affitti, premi cassa malati, imposte e spesa quotidiana nel 2026",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/swissminiatur.webp`, "width": 1344, "height": 756, "caption": "Modellini di edifici svizzeri allo Swissminiatur di Melide, simbolo del confronto tra i cantoni." },
  "datePublished": "2026-06-02T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-06-02T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Marco Ferrari", "jobTitle": "Esperto fiscalità frontaliera", "url": "https://frontaliereticino.ch/autori/marco-ferrari/", "sameAs": "https://www.linkedin.com/in/marco-ferrari-frontaliere-ticino/"},
@@ -48,7 +47,7 @@ const BLOG_CH_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "I premi dell'assicurazione malattia obbligatoria LAMal aumentano in media del 6% nel 2026 in tutti i cantoni svizzeri",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/bellinzona.webp`, "width": 1344, "height": 756, "caption": "Panorama di Bellinzona con i castelli medievali, capoluogo di un cantone tra i più cari per la cassa malati." },
  "datePublished": "2026-06-02T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-06-02T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Fiscale",
  "author": {"@type": "Person", "name": "Laura Bianchi", "jobTitle": "Specialista previdenza svizzera", "url": "https://frontaliereticino.ch/autori/laura-bianchi/", "sameAs": "https://www.linkedin.com/in/laura-bianchi-previdenza-svizzera/"},

--- a/services/seo/seo-blog.ts
+++ b/services/seo/seo-blog.ts
@@ -8,7 +8,6 @@
 import type { SEOMetadata } from '../seoService';
 
 const BASE_URL = 'https://frontaliereticino.ch';
-const BUILD_DATE_ISO = new Date().toISOString();
 
 const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  'blog-stipendio-netto-2026': {
@@ -25,7 +24,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "Guida completa al calcolo dello stipendio netto per chi lavora in Svizzera e risiede in Italia",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/lugano-view.webp`, "width": 1344, "height": 756, "caption": "Panorama di Lugano con il lago e le montagne sullo sfondo, simbolo del lavoro frontaliero in Ticino." },
  "datePublished": "2026-01-15T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-01-15T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Fiscale",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -49,7 +48,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "Confronto tra cassa malati svizzera e mutua italiana per frontalieri",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/mendrisio.webp`, "width": 1344, "height": 756, "caption": "Centro storico di Mendrisio al tramonto, porta d'ingresso del Ticino per i frontalieri." },
  "datePublished": "2026-01-05T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-01-05T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -74,7 +73,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "Tutto quello che devi preparare prima del primo giorno di lavoro in Svizzera",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/castelgrande.webp`, "width": 1344, "height": 756, "caption": "Castelgrande di Bellinzona visto dal basso, prima tappa del viaggio da frontaliere." },
  "datePublished": "2025-12-20T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2025-12-20T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -99,7 +98,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "Come calcolare la tredicesima netta di un frontaliere con tutte le deduzioni",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/locarno.webp`, "width": 1344, "height": 756, "caption": "Piazza Grande di Locarno con i portici, simbolo del reddito e della qualità di vita in Ticino." },
  "datePublished": "2025-12-15T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2025-12-15T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Fiscale",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -124,7 +123,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "Analisi vantaggi e svantaggi del pilastro 3a per chi lavora in Svizzera da frontaliere",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/monte-bre.webp`, "width": 1344, "height": 756, "caption": "Veduta dal Monte Brè su Lugano e il lago, metafora della pianificazione previdenziale a lungo termine." },
  "datePublished": "2025-12-10T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2025-12-10T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pensione",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -149,7 +148,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "Classifica dei comuni italiani di frontiera più convenienti per lavoratori frontalieri",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/gandria.webp`, "width": 1344, "height": 756, "caption": "Il borgo di Gandria affacciato sul lago di Lugano, esempio dei comuni di frontiera più ricercati." },
  "datePublished": "2025-12-05T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2025-12-05T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -174,7 +173,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "Confronto dettagliato dei costi tra vivere in Svizzera e in Italia per un frontaliere",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/foxtown.webp`, "width": 1344, "height": 756, "caption": "FoxTown Factory Stores a Mendrisio, simbolo dello shopping transfrontaliero tra Svizzera e Italia." },
  "datePublished": "2025-11-28T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2025-11-28T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -199,7 +198,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "La tassa sulla salute tra Italia e Ticino genera tensioni. Scopri le implicazioni per i frontalieri e le possibili soluzioni.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/bellinzona.webp`, "width": 1344, "height": 756, "caption": "Panorama di Bellinzona con i castelli medievali sullo sfondo delle Alpi ticinesi." },
  "datePublished": "2026-02-17T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-17T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Fiscale",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -224,7 +223,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "Sempre più ticinesi comprano casa in Italia per i prezzi proibitivi. Vantaggi, sfide e costo della vita a confronto.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/gandria.webp`, "width": 1344, "height": 756, "caption": "Veduta del borgo di Gandria sul lago di Lugano, meta ideale per chi cerca casa oltre confine." },
  "datePublished": "2026-02-17T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-17T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -249,7 +248,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "description": "Il franco svizzero continua a rafforzarsi sull'euro. Per i frontalieri che spendono in Italia, il tasso di cambio può valere centinaia di euro in più o in meno al mese.",
  "image": { "@type": "ImageObject", "acquireLicensePage": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "copyrightNotice": "© 2024–2026 Frontaliere Ticino. Tutti i diritti riservati.", "license": "https://frontaliereticino.ch/termini-di-servizio/#licenza-immagini", "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" }, "creditText": "Frontaliere Ticino", "url": `${BASE_URL}/images/places/lac-lugano.webp`, "width": 1344, "height": 756, "caption": "Veduta del lago di Lugano con le montagne, simbolo del franco forte e del lavoro frontaliero." },
  "datePublished": "2026-02-18T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-18T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Fiscale",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -279,7 +278,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di Lugano con lago e montagne; in primo piano, un laptop mostra un foglio di calcolo fiscale."
  },
  "datePublished": "2026-02-18T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-18T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Fiscale",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -309,7 +308,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Laptop con vista sul Lago di Lugano, che mostra un grafico finanziario. Simboleggia il telelavoro transfrontaliero tra Italia e Svizzera."
  },
  "datePublished": "2026-02-18T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-18T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Fiscale",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -339,7 +338,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista del Lago di Lugano da una postazione di telelavoro, simbolo del nuovo accordo per i frontalieri"
  },
  "datePublished": "2026-02-18T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-18T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Novità",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -369,7 +368,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Palazzo del Governo ticinese a Bellinzona, simbolo della tensione politica con l'Italia sulla tassa frontalieri.", 
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Fiscale",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -399,7 +398,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Scrivania di un frontaliere in telelavoro con vista sul Lago di Lugano, simbolo del nuovo accordo fiscale."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Fiscale",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -429,7 +428,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Corriere Smood in pausa sul lungolago di Lugano al tramonto, simbolo della fine delle attività dell'azienda in Ticino."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Novità",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -459,7 +458,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta del centro finanziario di Lugano con persone che camminano, simbolo del mercato del lavoro in Ticino."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Novità",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -489,7 +488,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Interno di una casa moderna in Ticino con termostato intelligente e vista sul Lago di Lugano, simbolo di efficienza energetica."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -519,7 +518,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Moderna pompa di calore installata fuori da una casa ticinese, simbolo di efficienza energetica e risparmio per i proprietari."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "inLanguage": "it",
  "articleSection": "Pratico",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
@@ -1404,7 +1403,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Permesso B svizzero su una scrivania con contratto di lavoro, simbolo dell'integrazione in Ticino."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/permesso-b-integrazione-tribunale-federale-ticino/`,
@@ -1432,7 +1431,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Ufficio moderno a Lugano con vista sul lago, simbolo del mercato del lavoro ticinese in evoluzione."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/tassazione-individuale-svizzera-impatto-lavoro-ticino-frontalieri/`,
@@ -1460,7 +1459,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Palazzo del Governo a Bellinzona con bandiere svizzera e italiana, simbolo delle tensioni fiscali sui ristorni."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/ristorni-frontalieri-scontro-ticino-berna-tassa-salute/`,
@@ -1488,7 +1487,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Traffico di frontalieri al mattino sull'autostrada A2 vicino al confine di Chiasso, con vista sul Ticino."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/pendolarismo-affitto-tempo-dilemma-frontalieri-ticino/`,
@@ -1516,7 +1515,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Il Palazzo delle Orsoline a Bellinzona, sede del governo ticinese, simbolo delle decisioni politiche sui ristorni dei frontalieri."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/centrodestra-ticino-stop-ristorni-frontalieri-tassa-salute/`,
@@ -1544,7 +1543,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Colonna di auto di frontalieri al valico di Chiasso-Brogeda, simbolo del mercato del lavoro transfrontaliero in Ticino."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/frontalieri-ticino-dati-calo-fine-2025/`,
@@ -1572,7 +1571,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta del valico di frontiera di Chiasso-Brogeda in Ticino, che mostra le infrastrutture doganali svizzere."
  },
  "datePublished": "2026-02-19T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-19T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/calo-entrate-irregolari-migranti-chiasso-ticino/`,
@@ -1600,7 +1599,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Coda di auto di frontalieri al valico di Brogeda (Chiasso) durante l'ora di punta mattutina verso il Ticino"
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1629,7 +1628,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta del valico di confine di Chiasso-Brogeda al tramonto, simbolo delle tensioni fiscali tra Ticino e Italia."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1658,7 +1657,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Busta paga svizzera con monete in franchi, simbolo del dibattito sul finanziamento della 13esima AVS in Ticino."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1687,7 +1686,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Busta paga svizzera e calcolatrice su una scrivania con vista sui castelli di Bellinzona, a simboleggiare il finanziamento della 13esima AVS."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1716,7 +1715,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Palazzo delle Orsoline a Bellinzona, sede del governo ticinese, con bandiere svizzere e cantonali."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1745,7 +1744,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Panorama del centro finanziario di Lugano al crepuscolo, simbolo dell'economia ticinese sotto pressione."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1774,7 +1773,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista dal cruscotto di un'auto al valico di frontiera di Chiasso-Brogeda, con un agente della dogana sullo sfondo."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1803,7 +1802,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Auto in coda al valico di Chiasso-Brogeda, simbolo del pendolarismo e del dibattito sui frontalieri in Ticino."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1832,7 +1831,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Mani di un frontaliere che calcolano lo stipendio netto in un ufficio a Lugano, con vista sul lago."
  },
  "datePublished": "2026-02-22T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-22T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1861,7 +1860,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Palazzo del Governo cantonale a Bellinzona, simbolo della politica ticinese al centro del dibattito sui ristorni"
  },
  "datePublished": "2026-02-20T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-20T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1890,7 +1889,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Palazzo del Governo ticinese a Bellinzona, simbolo della politica cantonale e delle decisioni sui frontalieri."
  },
  "datePublished": "2026-02-20T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-20T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1919,7 +1918,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Il Palazzo Federale a Berna, simbolo delle decisioni fiscali che impattano i conti della Svizzera e del Ticino."
  },
  "datePublished": "2026-02-20T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-20T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1948,7 +1947,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Busta paga svizzera su una scrivania con vista su Lugano, a simboleggiare l'impatto della 13esima AVS sullo stipendio dei frontalieri."
  },
  "datePublished": "2026-02-20T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-20T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -1977,7 +1976,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Palazzo del governo cantonale a Bellinzona, simbolo delle tensioni fiscali tra Ticino e Italia sui ristorni."
  },
  "datePublished": "2026-02-20T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-20T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2006,7 +2005,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Smartphone con app bancaria e vista sul lago di Lugano, simbolo di finanza sicura in Ticino."
  },
  "datePublished": "2026-02-20T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-20T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2035,7 +2034,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Moderno stabilimento industriale nel Mendrisiotto, Ticino, che simboleggia l'export verso gli USA"
  },
  "datePublished": "2026-02-20T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-20T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2064,7 +2063,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta del lungolago di Locarno, che ospita un importante settore sanitario privato, contesto dell'articolo."
  },
  "datePublished": "2026-02-20T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-20T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2093,7 +2092,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Scrivania di uno studio di architettura a Mendrisio con un contratto di lavoro svizzero, simbolo delle dispute salariali."
  },
  "datePublished": "2026-02-20T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-20T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2122,7 +2121,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Busta paga svizzera su una scrivania con vista sul Lago di Lugano, a simboleggiare l'impatto dei contributi AVS."
  },
  "datePublished": "2026-02-22T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-22T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2151,7 +2150,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Busta paga svizzera su una scrivania con vista su Lugano, a simboleggiare l'impatto della 13a AVS sullo stipendio dei frontalieri."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/tredicesima-avs-finanziamento-impatto-stipendio-frontalieri/`,
@@ -2179,7 +2178,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Polizia cantonale ticinese al lavoro con un tablet al valico di Chiasso-Brogeda, simbolo dello scambio dati."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/scambio-dati-polizia-svizzera-impatto-ticino/`,
@@ -2207,7 +2206,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Busta paga svizzera su una scrivania con vista sul lago di Lugano, a simboleggiare l'impatto delle trattenute AVS."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/tredicesima-avs-finanziamento-misto-stipendi-iva/`,
@@ -2235,7 +2234,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Ufficio moderno a Lugano con vista sul lago, simbolo del settore terziario qualificato in Ticino."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2264,7 +2263,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Busta paga svizzera su una scrivania con vista sul Lago di Lugano, focus sulle trattenute AVS."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2293,7 +2292,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Ufficio a Bellinzona con vista su Castelgrande, simbolo del mercato del lavoro e delle politiche cantonali in Ticino."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2322,7 +2321,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista del Castelgrande a Bellinzona, sede del governo ticinese, in un contesto di tensioni fiscali con la Lombardia."
  },
  "datePublished": "2026-02-21T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-21T00:00:00+01:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -2351,7 +2350,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Busta paga svizzera su una scrivania con vista sul Lago di Lugano, a simboleggiare il lavoro dei frontalieri in Ticino"
  },
  "datePublished": "2026-02-22T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-22T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/tredicesima-avs-finanziamento-contributi-iva-impatto-frontalieri/`,
@@ -2379,7 +2378,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Contatore dell'acqua in una cantina del Mendrisiotto, simbolo dell'aumento dei costi delle utenze in Ticino."
  },
  "datePublished": "2026-02-22T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-22T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/costo-acqua-mendrisiotto-aumento-tariffe-2026/`,
@@ -2407,7 +2406,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Collaborazione tra autorità svizzere e italiane al valico di frontiera di Chiasso, simbolo di cooperazione giudiziaria."
  },
  "datePublished": "2026-02-22T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-22T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/cooperazione-giudiziaria-svizzera-italia-impatto-frontalieri-ticino/`,
@@ -2435,7 +2434,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di una moderna clinica nel Locarnese, simbolo del settore sanitario ticinese e delle recenti ristrutturazioni."
  },
  "datePublished": "2026-02-22T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-22T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/sanita-locarnese-collaborazione-varini-hildebrand-licenziamenti/`,
@@ -2463,7 +2462,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Primo piano di un soffione della doccia con gocce d'acqua, a simboleggiare il rischio legionellosi in Ticino."
  },
  "datePublished": "2026-02-22T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-22T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/legionellosi-ticino-tasso-piu-alto-svizzera/`,
@@ -2491,7 +2490,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Etichetta di prezzo elettronica in un supermercato del Ticino, simbolo dei prezzi dinamici e del loro impatto sui consumatori."
  },
  "datePublished": "2026-02-22T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-22T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/prezzi-dinamici-ticino-rivoluzione-o-trappola-per-frontalieri/`,
@@ -2519,7 +2518,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Piazza della Riforma a Lugano in un giorno di sole, con tavolini all'aperto e una discreta presenza di polizia in sottofondo."
  },
  "datePublished": "2026-02-22T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-22T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/lugano-manifestazioni-polemica-regole-uguali-per-tutti/`,
@@ -2547,7 +2546,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Mappa dei comuni di frontiera tra Italia e Svizzera per la scelta della residenza fiscale dei frontalieri"
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/mappa-addizionale-irpef-comuni-confine-frontalieri-tasse/`,
@@ -2575,7 +2574,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica dal Mendrisiotto verso i comuni italiani di confine al tramonto, simbolo delle scelte fiscali dei frontalieri."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/addizionale-irpef-comuni-confine-mappa-tasse-frontalieri-2026/`,
@@ -2603,7 +2602,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Coppia di neogenitori frontalieri consulta i documenti per il congedo parentale in un appartamento in Ticino."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/maternita-paternita-frontaliere-svizzera-italia-guida-2026/`,
@@ -2631,7 +2630,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Dettaglio di una busta paga svizzera su una scrivania con vista sul Lago di Lugano, simbolo del lavoro frontaliere"
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/guida-contributi-sociali-svizzeri-busta-paga-frontaliere/`,
@@ -2659,7 +2658,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Balcone di un appartamento a Lugano con vista lago, simbolo del costo della vita per chi valuta il trasferimento in Ticino."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/quanto-costa-vivere-a-lugano-da-frontaliere-analisi-costi-2026/`,
@@ -2687,7 +2686,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Permesso G svizzero per frontalieri su una scrivania con vista su Lugano, simbolo del lavoro in Ticino."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/permesso-g-vantaggi-svantaggi-frontalieri-ticino-2026/`,
@@ -2715,7 +2714,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Coppia di frontalieri maturi pianifica la pensione con un tablet sul lungolago di Lugano, vista su Monte San Salvatore."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/calcolo-pensione-frontaliere-avs-inps-guida-completa/`,
@@ -2743,7 +2742,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Simulazione dell'impatto del nuovo accordo fiscale per frontalieri, vista dal cruscotto di un'auto al valico di Chiasso."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/frontaliere-nuovo-accordo-fiscale-2026-simulazione/`,
@@ -2771,7 +2770,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Scrivania con contratto di lavoro svizzero e passaporto italiano, con vista sul Lago di Lugano, simbolo della scelta assicurativa del frontaliere."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/lamal-o-cmi-frontaliere-quale-conviene-2026/`,
@@ -2799,7 +2798,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Documenti fiscali italiani e svizzeri su una scrivania di un frontaliere con vista su Mendrisio, Ticino."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/frontaliere-doppia-imposizione-credito-imposta-come-funziona/`,
@@ -2827,7 +2826,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista dal cruscotto di un'auto nel traffico mattutino verso il Ticino, simbolo dei costi del pendolarismo per i frontalieri."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/costo-auto-pendolare-frontaliere-ticino-2026/`,
@@ -2855,7 +2854,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Coppia di neogenitori frontalieri pianifica il congedo parentale su un tablet, con vista sul Lago di Lugano, Ticino."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/congedo-parentale-frontaliere-svizzera-italia-guida-2026/`,
@@ -2883,7 +2882,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Coda di auto di frontalieri al valico di Chiasso-Brogeda in Ticino al mattino presto."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/costo-auto-frontaliere-ticino-guida-completa-2026/`,
@@ -2911,7 +2910,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Frontaliere compila il Modello 730 con documenti svizzeri e italiani sulla scrivania con vista su Bellinzona."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/guida-dichiarazione-redditi-730-frontalieri-ticino/`,
@@ -2939,7 +2938,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Documenti necessari per lavorare in Svizzera, con un contratto e un Permesso G su una scrivania in Ticino."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/documenti-necessari-lavoro-svizzera-frontaliere-ticino/`,
@@ -2967,7 +2966,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Genitore frontaliere saluta il figlio all'ingresso di un moderno asilo nido in Ticino, simbolo delle scelte familiari."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/asilo-nido-svizzera-frontaliere-ticino-costi-guida/`,
@@ -2995,7 +2994,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta del lungolago di Locarno con edifici residenziali, simbolo del mercato immobiliare locale."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/locarno-stop-nuove-residenze-secondarie-quota-20/`,
@@ -3023,7 +3022,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Mappa del costo della vita in Svizzera su un tablet, con vista sul Lago di Lugano sullo sfondo."
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/costo-vita-svizzera-classifica-comuni-ticino/`,
@@ -3051,7 +3050,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Un cantiere edile in Ticino con un ispettore della sicurezza al lavoro, simbolo dei controlli nelle aziende"
  },
  "datePublished": "2026-02-23T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-23T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/sicurezza-lavoro-svizzera-audit-federale-falle-conflitti-suva/`,
@@ -3079,7 +3078,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Mappa del Canton Ticino con indicatori di costo della vita, vista da un appartamento con panorama su Lugano."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/costo-vita-svizzera-classifica-comuni-cari-economici/`,
@@ -3107,7 +3106,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Interno di uno studio di architettura a Mendrisio, con un giovane professionista che guarda fuori dalla finestra"
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/architetti-sottopagati-ticino-mendrisio-testimonianza/`,
@@ -3135,7 +3134,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Coda di automobili di lavoratori frontalieri al valico di Chiasso in una mattina lavorativa diretta verso il Ticino"
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/calo-frontalieri-ticino-economia-non-tassa-salute/`,
@@ -3163,7 +3162,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Lavoratrice frontaliere con il suo bambino guarda il Lago di Lugano, simbolo dei diritti di maternità transfrontalieri."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/maternita-frontaliere-cassazione-riconosce-indennita-inps/`,
@@ -3191,7 +3190,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Facciata di una farmacia moderna in una città del Ticino, simbolo del settore farmaceutico svizzero."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/galenica-chiude-bichsel-170-posti-a-rischio-impatto-ticino/`,
@@ -3219,7 +3218,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Polo industriale e logistico nel Mendrisiotto, simbolo dell'export ticinese verso gli Stati Uniti"
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/dazi-trump-usa-impatto-export-ticino-lavoro/`,
@@ -3247,7 +3246,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta dell'exclave di Campione d'Italia affacciata sul Lago di Lugano, simbolo della ripresa economica."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/campione-italia-fuori-dissesto-finanziario-nuove-assunzioni/`,
@@ -3275,7 +3274,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Un giovane architetto lavora fino a tardi in un ufficio a Mendrisio, simbolo delle pressioni nel settore."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/gavetta-tossica-architetti-ticino-denuncia/`,
@@ -3303,7 +3302,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Treno Eurocity delle FFS fermo in una stazione ticinese durante una mattinata di pendolarismo intenso."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/odissea-eurocity-milano-treno-bloccato-galleria-pendolari/`,
@@ -3331,7 +3330,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Ispettore della sicurezza sul lavoro in un cantiere edile in Ticino che controlla dei documenti"
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/sicurezza-lavoro-svizzera-controlli-insufficienti-suva/`,
@@ -3359,7 +3358,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di un moderno ufficio startup a Lugano con il team al lavoro e il lago e il Monte San Salvatore sullo sfondo."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/startup-svizzera-boom-investimenti-ia-opportunita-ticino/`,
@@ -3387,7 +3386,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Il Tribunale federale svizzero a Losanna, dove è stata presa la decisione sul Long Covid come malattia professionale."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/long-covid-malattia-professionale-sentenza-tribunale-federale/`,
@@ -3415,7 +3414,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Bandiere svizzera e dell'Unione Europea che sventolano con il lago di Lugano e il Monte San Salvatore sullo sfondo."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/accordo-ue-svizzera-mercato-interno-impatto-frontalieri/`,
@@ -3443,7 +3442,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Interno di una moderna fonderia nel Canton Ticino, con un operaio specializzato che ispeziona un pezzo metallico."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/fonderie-svizzere-crisi-produzione-2025-impatto-ticino/`,
@@ -3471,7 +3470,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Palazzo del Governo a Bellinzona, dove si discutono le politiche salariali del Canton Ticino"
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/salario-minimo-ticino-accordo-aumento-22-franchi/`,
@@ -3499,7 +3498,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Un treno TILO fermo alla stazione di Bellinzona, simbolo del pendolarismo dei frontalieri in Ticino."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/trasporti-pubblici-svizzera-crescita-fatturato-impatto-frontalieri/`,
@@ -3527,7 +3526,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Lavori stradali notturni in una via di Lugano, con macchinari per la posa dell'asfalto illuminati da fari."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/lavori-notturni-lugano-marzo-2026-strade-chiuse/`,
@@ -3555,7 +3554,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "La moderna sede della SUPSI a Manno, Canton Ticino, che ospita il Dipartimento formazione e apprendimento."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/supsi-daniela-willi-piezzi-direttrice-dipartimento-formazione/`,
@@ -3583,7 +3582,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Sede di una banca moderna a Lugano, simbolo della stabilità finanziaria del Canton Ticino."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/bps-suisse-risultati-solidi-2025-impatto-bper-frontalieri/`,
@@ -3611,7 +3610,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Linee elettriche ad alta tensione che attraversano una valle del Ticino, simbolo del settore energetico svizzero."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/aiuti-imprese-energetiche-proroga-taglio-fondi/`,
@@ -3639,7 +3638,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Sala riunioni del Gran Consiglio a Bellinzona, simbolo del dibattito politico sul salario minimo in Ticino."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/salario-minimo-sociale-ticino-dibattito-frontalieri/`,
@@ -3667,7 +3666,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Sede di una banca a Lugano con vista sul lago, a simboleggiare i risultati finanziari di BPS Suisse in Ticino"
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/bps-suisse-utili-record-consigli-frontalieri/`,
@@ -3695,7 +3694,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Palazzo del governo cantonale a Bellinzona con bandiere svizzera e ticinese, simbolo della politica ticinese sull'accordo UE."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/accordo-ue-svizzera-ticino-chiede-referendum-obbligatorio/`,
@@ -3723,7 +3722,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Le bandiere della Svizzera e dell'Unione Europea sventolano insieme, simbolo del nuovo pacchetto di accordi bilaterali."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/accordo-svizzera-ue-cosa-cambia-frontalieri-ticino/`,
@@ -3751,7 +3750,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista del lungolago di Locarno con gli edifici della città e le montagne circostanti, che simboleggiano il mercato immobiliare locale."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/locarno-stop-licenze-case-secondarie/`,
@@ -3779,7 +3778,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta del confine italo-svizzero di Chiasso, simbolo degli accordi bilaterali tra Svizzera e Unione Europea."
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/accordi-ue-svizzera-firma-vicina-cosa-cambia-frontalieri/`,
@@ -3807,7 +3806,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Scontrino della spesa in un supermercato ticinese, a simboleggiare l'impatto dell'aumento IVA sul costo della vita"
  },
  "datePublished": "2026-02-24T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-24T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/aumento-iva-svizzera-esercito-impatto-stipendio-frontalieri/`,
@@ -3835,7 +3834,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Famiglia passeggia vicino al Lago di Lugano in primavera."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/maternita-paternita-ticino/`,
@@ -3862,7 +3861,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista autunnale della valle di Poschiavo con edifici storici e un treno della Ferrovia retica."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/turismo-valposchiavo-2025/`,
@@ -3890,7 +3889,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Traffico di frontalieri al valico di Ponte Tresa con montagne sullo sfondo"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/frontalieri-economia-ticino/`,
@@ -3918,7 +3917,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista del lago di Lugano con bandiere svizzere all'alba e skyline in lontananza"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/inflazione-frontalieri-ticino/`,
@@ -3946,7 +3945,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta di Lugano con un edificio bancario e pedoni che attraversano la strada"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/aprire-conto-bancario-frontalieri/`,
@@ -3974,7 +3973,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Valico di Mendrisio con auto in transito e bandiera svizzera visibile"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/ristorni-fiscali-frontaliere/`,
@@ -4002,7 +4001,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta di Mendrisio con frontalieri in transito vicino a un ufficio locale"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/contributi-sociali-busta-paga/`,
@@ -4030,7 +4029,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Strada cantonale tra Vezia e Cureglia, con guardrail e curve pericolose in una giornata di sole"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/strada-incidenti-vezia-cureglia/`,
@@ -4058,7 +4057,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Famiglia in un ufficio sanitario a Lugano che discute di assicurazione malattia."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/assicurazione-malattia-famiglia/`,
@@ -4085,7 +4084,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Valico di Mendrisio con auto in coda e Alpi sullo sfondo"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/frontalieri-calo-economia-ticinese/`,
@@ -4113,7 +4112,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista del campus USI a Lugano con studenti e imprenditori in primo piano"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/usi-centro-startup-classifica/`,
@@ -4141,7 +4140,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Treno Tilo alla stazione di Lugano con vista sul lago."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/sciopero-treni-tilo-febbraio-2026/`,
@@ -4169,7 +4168,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "La piscina comunale di Chiasso con la nuova copertura pressostatica in autunno."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/piscina-chiasso-copertura/`,
@@ -4197,7 +4196,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Centrale elettrica di Grono riattivata, contornata da montagne e vegetazione"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/centrale-elettrica-grono-attiva/`,
@@ -4225,7 +4224,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Valico di confine tra Italia e Svizzera a Chiasso, con auto e pedoni"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/naspi-frontaliere-italia-requisiti/`,
@@ -4253,7 +4252,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di Lugano con lago e montagne sullo sfondo."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/prelievo-secondo-pilastro-frontaliere/`,
@@ -4281,7 +4280,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di Lugano con il lago e le montagne sullo sfondo, in una giornata soleggiata."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/accordo-ue-frontalieri-ticino/`,
@@ -4309,7 +4308,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta di Castelgrande a Bellinzona con cielo nuvoloso e la città sullo sfondo"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/ristorni-congelati-ticino-italia/`,
@@ -4338,7 +4337,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista serena del Lago di Lugano al tramonto con colline e paesaggio urbano."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/naspi-ex-frontalieri-2026/`,
@@ -4398,7 +4397,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di un tipico borgo italiano vicino al confine svizzero, con tetti in terracotta e colline sullo sfondo al tramonto"
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/mutuo-casa-frontalieri-italia/`,
@@ -4448,7 +4447,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Lavori per la sostituzione della copertura della piscina di Chiasso in una giornata di sole."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/piscina-chiasso-investimento/`,
@@ -4476,7 +4475,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Piazza principale di Bellinzona con il palazzo del governo sullo sfondo e persone che passeggiano."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/ristorni-congelati-gobbi-2026/`,
@@ -4504,7 +4503,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Un asilo moderno a Lugano con bambini che giocano all'esterno."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/asilo-nido-ticino-guida-2026/`,
@@ -4532,7 +4531,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Mercato di Bellinzona con venditori e acquirenti, colori vivaci e prodotti freschi."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/ristorni-salute-2026-ticino/`,
@@ -4560,7 +4559,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Palazzo del Governo a Bellinzona, simbolo delle istituzioni ticinesi, in un contesto di tensioni sui ristorni fiscali e la tassa sulla salute."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/tassa-salute-scontro-ticino-berna/`,
@@ -4588,7 +4587,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "La piscina comunale di Chiasso con la copertura pressostatica usurata e le montagne sullo sfondo, simbolo di un imminente rinnovamento."
  },
  "datePublished": "2026-02-25T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-25T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/piscina-chiasso-rinnovo-copertura-sicurezza/`,
@@ -4616,7 +4615,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Pendolari in attesa alla stazione di Chiasso o Mendrisio, con un treno Tilo in arrivo sullo sfondo, al mattino presto."
  },
  "datePublished": "2026-02-26T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/sciopero-tilo-italia-disagi-frontalieri/`,
@@ -4644,7 +4643,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Treno TILO in arrivo alla stazione di Mendrisio con pendolari frontalieri."
  },
  "datePublished": "2026-02-26T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/abbonamenti-sconti-treni-ticino/`,
@@ -4672,7 +4671,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Famiglie che passeggiano nella piazza di Mendrisio con le Alpi sullo sfondo in una giornata di sole."
  },
  "datePublished": "2026-02-26T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/bonus-famiglia-frontalieri-2026/`,
@@ -4700,7 +4699,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Un frontaliere lavora da casa con vista sul Lago di Lugano."
  },
  "datePublished": "2026-02-26T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/smart-working-frontalieri-regole/`,
@@ -4728,7 +4727,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Auto parcheggiata vicino al valico di Ponte Tresa con il paesaggio ticinese sullo sfondo"
  },
  "datePublished": "2026-02-26T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T00:00:00+01:00",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
  "mainEntityOfPage": `${BASE_URL}/articoli-frontaliere/confronto-assicurazioni-auto/`,
@@ -4756,7 +4755,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Valico di confine Brogeda tra Italia e Svizzera con auto in transito"
  },
  "datePublished": "2026-02-26T10:55:41+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T10:55:41+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4785,7 +4784,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Un ospedale a Mendrisio con bandiere svizzere e italiane"
  },
  "datePublished": "2026-02-26T11:12:45+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T11:12:45+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4817,7 +4816,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di Bellinzona con il Castelgrande sullo sfondo in primavera"
  },
  "datePublished": "2026-02-26T13:36:25+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T13:36:25+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4846,7 +4845,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Traffico congestionato al valico di Chiasso con lavori sulla A9 visibili."
  },
  "datePublished": "2026-02-26T14:42:47+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T14:42:47+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4875,7 +4874,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista del Seghezzone a Giubiasco con moduli prefabbricati in costruzione e montagne sullo sfondo"
  },
  "datePublished": "2026-02-26T17:55:05+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T17:55:05+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4904,7 +4903,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Auto in coda al valico di Chiasso con segnaletica stradale visibile."
  },
  "datePublished": "2026-02-26T20:30:48+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-26T20:30:48+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4933,7 +4932,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di Lugano con il lago e le montagne sullo sfondo"
  },
  "datePublished": "2026-02-27T05:10:08+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T05:10:08+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4962,7 +4961,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Un'auto di lusso fermata dalla polizia al confine in Ticino, con le Alpi sullo sfondo"
  },
  "datePublished": "2026-02-27T06:11:51+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T06:11:51+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -4991,7 +4990,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Valico di frontiera a Mendrisio con auto in coda e montagne sullo sfondo."
  },
  "datePublished": "2026-02-27T06:19:48+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T06:19:48+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5020,7 +5019,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta del Castelgrande di Bellinzona in Ticino, con un edificio amministrativo in primo piano"
  },
  "datePublished": "2026-02-27T10:11:45+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T10:11:45+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5049,7 +5048,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Coda al confine svizzero-italiano vicino a Brogeda con segnaletica stradale e cantieri in corso"
  },
  "datePublished": "2026-02-27T14:13:03+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T14:13:03+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5078,7 +5077,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di un serbatoio idrico a Magliaso circondato da verde e Alpi."
  },
  "datePublished": "2026-02-27T17:02:40+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T17:02:40+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5107,7 +5106,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Ospedale a Bellinzona con montagne sullo sfondo, giornata soleggiata."
  },
  "datePublished": "2026-02-27T18:09:17+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T18:09:17+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5136,7 +5135,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Ingresso di un cinema a Varese con il poster del film 'Frontaliers Sabotage' all'entrata"
  },
  "datePublished": "2026-02-27T19:35:50+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T19:35:50+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5165,7 +5164,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista del valico doganale di Ponte Chiasso con auto in coda sotto un cielo nuvoloso."
  },
  "datePublished": "2026-02-27T20:02:09+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T20:02:09+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5194,7 +5193,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Mendrisio, vista del valico di frontiera con auto e biciclette in transito, montagne sullo sfondo"
  },
  "datePublished": "2026-02-27T21:01:10+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T21:01:10+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5223,7 +5222,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Persone di diverse religioni fuori da una chiesa a Bellinzona, con il Castelgrande sullo sfondo"
  },
  "datePublished": "2026-02-27T22:03:04+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T22:03:04+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5252,7 +5251,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Bellinzona, cittadini che si recano a votare presso un edificio storico."
  },
  "datePublished": "2026-02-27T22:57:44+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T22:57:44+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5281,7 +5280,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Cantiere sul lungolago vicino a un caffè con piante verdi"
  },
  "datePublished": "2026-02-27T23:45:47+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-27T23:45:47+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5310,7 +5309,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Postazione mobile di controllo velocità su una strada panoramica in Ticino, con la polizia e le Alpi sullo sfondo."
  },
  "datePublished": "2026-02-28T04:40:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T04:40:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5339,7 +5338,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista del lungolago di Lugano al tramonto con persone a un evento culturale"
  },
  "datePublished": "2026-02-28T06:02:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T06:02:12+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5368,7 +5367,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Piazza di una città ticinese con stazione e passanti"
  },
  "datePublished": "2026-02-28T07:09:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T07:09:07+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5397,7 +5396,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Passaggio di frontiera tra Italia e Svizzera al Ponte Chiasso, con montagne sullo sfondo."
  },
  "datePublished": "2026-02-28T08:58:42+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T08:58:42+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5426,7 +5425,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Un seggio elettorale a Bellinzona durante le elezioni comunali, con persone che votano e bandiere svizzere in vista."
  },
  "datePublished": "2026-02-28T11:21:53+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T11:21:53+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5455,7 +5454,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Valico di Chiasso-Brogeda con auto in fila per i controlli doganali"
  },
  "datePublished": "2026-02-28T11:43:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-02-28T11:43:07+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5484,7 +5483,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Un tram 42 che attraversa la città di Lugano, in una giornata soleggiata dell'autunno in Ticino."
  },
  "datePublished": "2026-03-16T06:20:08+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-16T06:20:08+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5512,7 +5511,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Un'auto fermata al valico autostradale di Brogeda."
  },
  "datePublished": "2026-03-16T10:02:17+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-16T10:02:17+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5541,7 +5540,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veicolo con targhe svizzere al valico di Chiasso"
  },
  "datePublished": "2026-03-16T10:58:26+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-16T10:58:26+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5570,7 +5569,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Scena fotorealistica di Lugano con montagne e lago"
  },
  "datePublished": "2026-03-16T12:06:51+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-16T12:06:51+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5599,7 +5598,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Apprendisti in aula professionale a Mendrisio"
  },
  "datePublished": "2026-03-16T20:06:55+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-16T20:06:55+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5628,7 +5627,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Una famiglia felice a passeggio nel centro storico di Bellinzona, Svizzera."
  },
  "datePublished": "2026-03-16T20:55:08+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-16T20:55:08+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5657,7 +5656,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Paesaggio urbano di Locarno con lago"
  },
  "datePublished": "2026-03-16T21:56:27+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-16T21:56:27+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5685,7 +5684,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Sequestro di droga al valico di Brogeda, Ticino"
  },
  "datePublished": "2026-03-16T23:52:14+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-16T23:52:14+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5714,7 +5713,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Autosilo interrato a Bellinzona."
  },
  "datePublished": "2026-03-17T08:12:10+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-17T08:12:10+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5743,7 +5742,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista mattutina sul lago di Varese con le Alpi svizzere sullo sfondo"
  },
  "datePublished": "2026-03-17T11:07:59+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-17T11:07:59+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5772,7 +5771,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con il lago e le montagne circostanti"
  },
  "datePublished": "2026-03-17T12:08:54+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-17T12:08:54+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5801,7 +5800,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Folla al Carnevale di Chiasso con agenti di sicurezza privata in primo piano"
  },
  "datePublished": "2026-03-17T15:30:59+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-17T15:30:59+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5830,7 +5829,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Corriere a domicilio in bicicletta a Lugano, Canton Ticino, con borse termiche per consegne"
  },
  "datePublished": "2026-03-17T17:29:41+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-17T17:29:41+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5859,7 +5858,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Una giovane donna cerca di trovare un appartamento in una zona residenziale di Lugano, marzo 2026"
  },
  "datePublished": "2026-03-17T19:27:49+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-17T19:27:49+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5888,7 +5887,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Controllo doganale Brogeda-Chiasso con sequestro record di cocaina"
  },
  "datePublished": "2026-03-17T21:08:34+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-17T21:08:34+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5917,7 +5916,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Bellinzona, con il Castelgrande in primo piano"
  },
  "datePublished": "2026-03-17T22:02:23+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-17T22:02:23+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -5946,7 +5945,7 @@ const BLOG_SEO_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di Lugano dal lago."
  },
  "datePublished": "2026-03-17T23:01:33+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-17T23:01:33+00:00",
  "inLanguage": "it",
  "author": {"@type": "Person", "name": "Valerie Linc", "jobTitle": "Esperta fiscale frontalieri", "url": "https://frontaliereticino.ch/chi-siamo/", "sameAs": "https://www.linkedin.com/in/valerie-linc/"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},

--- a/services/seo/seo-pages.ts
+++ b/services/seo/seo-pages.ts
@@ -11,14 +11,6 @@ import { EXCHANGE_RATE_EUR } from './exchangeRateMeta';
 const BASE_URL = 'https://frontaliereticino.ch';
 
 /**
- * Dynamic build-time dateModified for content pages.
- * AI systems weight freshness heavily — this ensures every build emits a
- * current timestamp so crawlers see up-to-date signals without manual edits.
- * datePublished stays fixed (original creation date); only dateModified moves.
- */
-const BUILD_DATE_ISO = new Date().toISOString();
-
-/**
  * SpeakableSpecification for section landings and content pages.
  * Voice assistants and AI readers use this to identify key passages
  * for spoken answers and cited snippets.
@@ -1015,7 +1007,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "applicationCategory": "FinanceApplication",
  "operatingSystem": "Web",
  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "CHF" },
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-07-04T00:00:00+02:00",
  "provider": {
  "@type": "Organization",
  "name": "Frontaliere Ticino",
@@ -1448,7 +1440,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "@type": "Dataset",
  "name": "Statistiche frontalieri e osservatorio offerte lavoro Ticino 2026",
  "description": "Dati statistici sui frontalieri svizzeri-italiani e osservatorio del job board Ticino: numero permessi G, aziende attive, localities, trend offerte e statistiche BFS 2026.",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2024-01-01",
  "datePublished": "2024-01-01",
  "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" },
  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
@@ -1568,7 +1560,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO
+ "dateModified": "2026-01-01T00:00:00+01:00"
  },
  {
  "@context": "https://schema.org",
@@ -1636,7 +1628,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO
+ "dateModified": "2026-01-01T00:00:00+01:00"
  },
  {
  "@context": "https://schema.org",
@@ -2030,7 +2022,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO
+ "dateModified": "2026-01-01T00:00:00+01:00"
  }
  },
 
@@ -2050,7 +2042,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO
+ "dateModified": "2026-01-01T00:00:00+01:00"
  }
  },
 
@@ -2071,7 +2063,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO
+ "dateModified": "2026-01-01T00:00:00+01:00"
  },
  {
  "@context": "https://schema.org",
@@ -2224,7 +2216,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO
+ "dateModified": "2026-01-01T00:00:00+01:00"
  }
  },
 
@@ -2245,7 +2237,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO
+ "dateModified": "2026-01-01T00:00:00+01:00"
  },
  {
  "@context": "https://schema.org",
@@ -2289,7 +2281,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO
+ "dateModified": "2026-01-01T00:00:00+01:00"
  },
  {
  "@context": "https://schema.org",
@@ -2385,7 +2377,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-01-01T00:00:00+01:00",
  "keywords": "festività ticino 2026, giorni festivi ticino, calendario ticino 2026",
  "speakable": SPEAKABLE_SECTION
  },
@@ -2486,7 +2478,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "de",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-01-01T00:00:00+01:00",
  "keywords": "feiertage tessin 2026, feiertage kanton tessin, kalender tessin 2026",
  "speakable": SPEAKABLE_SECTION
  },
@@ -2684,7 +2676,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "datePublished": "2026-01-01T00:00:00+01:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-01-01T00:00:00+01:00",
  "keywords": "mappa confine italia svizzera, valichi ticino, comuni frontalieri 20 km, addizionali irpef frontiera",
  "speakable": SPEAKABLE_SECTION
  },
@@ -4249,7 +4241,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "name": "Confronto Stipendi Frontalieri Svizzera-Italia 2026",
  "url": `${BASE_URL}/statistiche/confronta-stipendi/`,
  "description": "Database salariale con 60 professioni in 15 settori: range min-mediano-max per livello junior, mid e senior. Dati Svizzera (CHF) e Italia (EUR) per lavoratori frontalieri.",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2024-06-01",
  "datePublished": "2024-06-01",
  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
  "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" },
@@ -4290,7 +4282,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "name": "Classifica Migliori Comuni di Frontiera 2026",
  "url": `${BASE_URL}/statistiche/migliori-comuni-frontiera/`,
  "description": "Classifica dei migliori comuni italiani di frontiera per qualità della vita, servizi e distanza dalla dogana",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2024-06-01",
  "datePublished": "2024-06-01",
  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
  "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" },
@@ -4319,7 +4311,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "name": "Osservatorio stipendi e lavori in Ticino",
  "url": `${BASE_URL}/statistiche/osservatorio-stipendi-lavori-ticino/`,
  "description": "Osservatorio giornaliero del job board Frontaliere Ticino con trend annunci, aziende attive, localita piu dinamiche e salary range osservati nelle offerte.",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2024-06-01",
  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
  "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" },
  "datePublished": "2024-06-01",
@@ -4357,7 +4349,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "name": "Storico Traffico Dogane Svizzera-Italia",
  "url": `${BASE_URL}/statistiche/storico-traffico-dogane/`,
  "description": "Dati storici del traffico ai valichi di frontiera tra Svizzera e Italia con tendenze e confronti",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2024-01-01",
  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
  "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" },
  "datePublished": "2024-01-01",
@@ -4385,7 +4377,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "name": "Tasso di Disoccupazione Svizzera",
  "url": `${BASE_URL}/statistiche/disoccupazione-svizzera/`,
  "description": "Serie storica mensile del tasso di disoccupazione registrata in Svizzera (SECO) dal 2016",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2016-01-01",
  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
  "creator": { "@type": "Organization", "name": "SECO — Segreteria di Stato dell'economia", "url": "https://www.seco.admin.ch" },
  "datePublished": "2016-01-01",
@@ -4431,7 +4423,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "name": "Prezzi benzina al confine Italia-Svizzera",
  "url": `${BASE_URL}/statistiche/prezzi-benzina-confine/`,
  "description": "Dataset comparativo dei prezzi benzina tra comuni di confine italiani e stazioni svizzere dell'area di frontiera.",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2024-01-01",
  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
  "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" },
  "datePublished": "2024-01-01",
@@ -4460,7 +4452,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "name": "Premi cassa malati per comune svizzero",
  "url": `${BASE_URL}/statistiche/premi-malattia-comuni/`,
  "description": "Dataset dei premi LAMal per comune e cantone svizzero, con evoluzione storica e confronto tra fasce d'età.",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2024-01-01",
  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
  "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" },
  "datePublished": "2024-01-01",
@@ -4522,7 +4514,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "name": "Ristorni Fiscali Frontalieri per Comune",
  "url": `${BASE_URL}/tasse-e-pensione/ristorni-fiscali/`,
  "description": "Statistiche sui ristorni fiscali versati ai comuni italiani di frontiera",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2024-01-01",
  "license": "https://creativecommons.org/licenses/by-nc/4.0/",
  "creator": { "@type": "Organization", "name": "Frontaliere Ticino", "url": "https://frontaliereticino.ch/" },
  "datePublished": "2024-01-01",
@@ -8396,7 +8388,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di Lugano con lago e montagne circostanti."
  },
  "datePublished": "2026-03-03T14:39:51+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-03T14:39:51+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8425,7 +8417,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Panorama di Lugano al tramonto sul lago"
  },
  "datePublished": "2026-03-04T07:43:28+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-04T07:43:28+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8454,7 +8446,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista di Bellinzona con i suoi castelli storici e la vita cittadina."
  },
  "datePublished": "2026-03-04T08:11:51+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-04T08:11:51+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8483,7 +8475,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Infermieri al lavoro in un ospedale del Ticino"
  },
  "datePublished": "2026-03-04T10:17:08+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-04T10:17:08+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8512,7 +8504,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Panorama di Lugano con vista sul lago"
  },
  "datePublished": "2026-03-04T12:09:08+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-04T12:09:08+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8541,7 +8533,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Bellinzona con i suoi castelli storici."
  },
  "datePublished": "2026-03-04T14:22:12+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-04T14:22:12+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8570,7 +8562,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Panorama di Lugano con grafico in calo"
  },
  "datePublished": "2026-03-04T17:38:10+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-04T17:38:10+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8599,7 +8591,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del Medio Vedeggio con i comuni di Bedano, Cadempino, Gravesano e Lamone in Ticino"
  },
  "datePublished": "2026-03-04T20:08:46+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-04T20:08:46+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8628,7 +8620,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica dell'aeroporto di Lugano con il lago e la città sullo sfondo in Ticino."
  },
  "datePublished": "2026-03-04T21:05:31+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-04T21:05:31+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8657,7 +8649,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con lago e montagne sullo sfondo in una giornata limpida di primavera"
  },
  "datePublished": "2026-03-04T23:07:46+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-04T23:07:46+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8686,7 +8678,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con lavoratori frontalieri che attraversano un ponte, simbolo dell’economia ticinese"
  },
  "datePublished": "2026-03-05T05:06:52+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-05T05:06:52+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8715,7 +8707,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con il lago e le montagne sullo sfondo in Ticino"
  },
  "datePublished": "2026-03-05T08:01:20+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-05T08:01:20+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8744,7 +8736,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Stazione di Lugano affollata con passeggeri TILO nel 2025, vista urbana del Canton Ticino"
  },
  "datePublished": "2026-03-05T10:11:48+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-05T10:11:48+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8773,7 +8765,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Frontalieri che si recano al lavoro a Locarno"
  },
  "datePublished": "2026-03-05T12:12:19+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-05T12:12:19+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8802,7 +8794,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Panoramica di Lugano con stazione ferroviaria"
  },
  "datePublished": "2026-03-05T14:46:54+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-05T14:46:54+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8831,7 +8823,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Treno Tilo in viaggio verso il Canton Ticino."
  },
  "datePublished": "2026-03-05T21:55:24+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-05T21:55:24+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8860,7 +8852,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista del valico di Brogeda tra Ticino e Italia con traffico e paesaggi naturali"
  },
  "datePublished": "2026-03-06T00:03:53+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T00:03:53+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8889,7 +8881,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Stazione di rifornimento a Lugano, auto in attesa di carburante, paesaggio Ticino."
  },
  "datePublished": "2026-03-06T10:00:10+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T10:00:10+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8918,7 +8910,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Paesaggio montano nel Ticino con valico e strada, scenario realistico"
  },
  "datePublished": "2026-03-06T11:19:03+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T11:19:03+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8947,7 +8939,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista storica di Bellinzona, Ticino con architettura affascinante al tramonto."
  },
  "datePublished": "2026-03-06T14:11:24+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T14:11:24+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -8976,7 +8968,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Panoramica di Lugano, con il lago e gli edifici moderni."
  },
  "datePublished": "2026-03-06T16:10:57+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T16:10:57+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9005,7 +8997,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del Lago di Lugano con montagne sullo sfondo."
  },
  "datePublished": "2026-03-06T18:10:25+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T18:10:25+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9034,7 +9026,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Bellinzona con i suoi castelli storici."
  },
  "datePublished": "2026-03-06T20:06:08+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T20:06:08+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9063,7 +9055,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista del Lago di Lugano con montagne circostanti, rappresentante l'influenza svizzera e italiana."
  },
  "datePublished": "2026-03-06T21:06:25+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T21:06:25+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9092,7 +9084,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con lago e montagne."
  },
  "datePublished": "2026-03-06T22:04:08+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T22:04:08+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9121,7 +9113,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con montagne sullo sfondo."
  },
  "datePublished": "2026-03-06T23:12:41+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T23:12:41+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9150,7 +9142,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Acquirenti soddisfatti escono da Foxtown, il famoso outlet di Mendrisio, con i loro acquisti."
  },
  "datePublished": "2026-03-06T23:56:51+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-06T23:56:51+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9179,7 +9171,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Valico di Gaggiolo in Ticino con vista sul confine italo-svizzero durante le votazioni del 8 marzo."
  },
  "datePublished": "2026-03-07T04:47:30+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T04:47:30+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9208,7 +9200,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Valico di Gaggiolo in Ticino con vista su Lugano e il Lago Maggiore"
  },
  "datePublished": "2026-03-07T06:05:59+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T06:05:59+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9237,7 +9229,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Valico frontaliero in Ticino con controlli di sicurezza, scena realistica"
  },
  "datePublished": "2026-03-07T07:52:55+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T07:52:55+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9266,7 +9258,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Auto in transito sul valico di Gaggiolo, confine tra Italia e Svizzera, con paesaggio ticinese sullo sfondo"
  },
  "datePublished": "2026-03-07T09:01:01+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T09:01:01+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9295,7 +9287,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Panorama di Locarno con Lago Maggiore e montagne, scena fotorealistica DSLR."
  },
  "datePublished": "2026-03-07T09:56:44+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T09:56:44+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9324,7 +9316,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Infermiere che assiste una persona anziana a domicilio a Lugano, Ticino"
  },
  "datePublished": "2026-03-07T10:53:30+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T10:53:30+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9353,7 +9345,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista urbana di Lugano con autobus e parcheggio park and ride poco utilizzato"
  },
  "datePublished": "2026-03-07T11:41:11+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T11:41:11+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9382,7 +9374,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica del Lago di Lugano durante il tramonto, con riflessi sull'acqua."
  },
  "datePublished": "2026-03-07T13:54:36+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T13:54:36+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9411,7 +9403,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Turisti svizzeri in attesa di informazioni in un valico di frontiera."
  },
  "datePublished": "2026-03-07T14:54:22+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T14:54:22+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9440,7 +9432,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Volo di rimpatrio da Mascate, Oman, verso Zurigo, Svizzera."
  },
  "datePublished": "2026-03-07T15:51:15+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T15:51:15+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9469,7 +9461,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Scuole di Ticino con segni di sicurezza antincendio. Vista aerea con montagne in sfondo."
  },
  "datePublished": "2026-03-07T17:00:20+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T17:00:20+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9498,7 +9490,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Impresa varesina che esporta macchinari e prodotti chimici in India. Vista panoramica dal Lago di Lugano."
  },
  "datePublished": "2026-03-07T17:48:07+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-07T17:48:07+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9527,7 +9519,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Camion parcheggiato vicino al valico di Chiasso con vista sul paesaggio del Ticino al tramonto"
  },
  "datePublished": "2026-03-08T10:57:24+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-08T10:57:24+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9556,7 +9548,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Stazione di servizio al confine Ticino-Lombardia con auto in attesa e cartelloni prezzi al mattino"
  },
  "datePublished": "2026-03-08T11:45:19+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-08T11:45:19+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9585,7 +9577,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Elettori davanti a un seggio a Bellinzona con bandiere svizzere e scatole per le schede, luce invernale naturale."
  },
  "datePublished": "2026-03-08T13:59:41+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-08T13:59:41+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9614,7 +9606,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Veduta fotorealistica di Lugano con pendolare sul lungolago e skyline al mattino"
  },
  "datePublished": "2026-03-08T15:03:13+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-08T15:03:13+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9643,7 +9635,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "caption": "Vista panoramica di Lugano con lago e montagne."
  },
  "datePublished": "2026-03-08T15:50:38+00:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-08T15:50:38+00:00",
  "inLanguage": "it",
  "author": {"@id": "https://frontaliereticino.ch/#organization"},
  "publisher": {"@id": "https://frontaliereticino.ch/#organization"},
@@ -9668,7 +9660,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "description": "La guida definitiva per lavoratori frontalieri Italia-Svizzera: permesso G, regime fiscale nuovo accordo, contributi sociali AVS/LPP, assicurazione LAMal, pendolarismo e dichiarazione dei redditi. Aggiornata al 2026.",
  "url": `${BASE_URL}/guida-frontaliere/guida-completa-lavoro-frontaliere-svizzera-2026/`,
  "datePublished": "2026-03-31T08:00:00+02:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-03-31T08:00:00+02:00",
  "inLanguage": "it",
  "author": { "@id": "https://frontaliereticino.ch/#organization" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
@@ -9815,7 +9807,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "description": "Guida esaustiva alla tassazione dei frontalieri Italia-Svizzera nel 2026: Nuovo Accordo del 17 luglio 2023, doppia imposizione, confronto permesso G vs B, aliquote d'imposta alla fonte Ticino, deduzioni fiscali, casi particolari e dichiarazione dei redditi.",
  "url": `${BASE_URL}/guida-tassazione-frontalieri-2026/`,
  "datePublished": "2026-04-22T08:00:00+02:00",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-22T08:00:00+02:00",
  "inLanguage": "it",
  "author": { "@id": "https://frontaliereticino.ch/#organization" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
@@ -10070,7 +10062,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "name": "Metodologia editoriale — Come scriviamo gli articoli",
  "url": `${BASE_URL}/metodologia/`,
  "description": "Come utilizziamo l'IA generativa, le fonti primarie e il processo di revisione editoriale per garantire accuratezza e trasparenza.",
- "lastReviewed": BUILD_DATE_ISO,
+ "lastReviewed": "2026-06-16T00:00:00+02:00",
  "inLanguage": "it",
  "isPartOf": { "@id": `${BASE_URL}/#website` },
  "about": {
@@ -10177,7 +10169,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "author": { "@type": "Organization", "name": "Frontaliere Ticino" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
  "datePublished": "2026-04-22",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-22",
  "inLanguage": "it",
  "mainEntityOfPage": `${BASE_URL}/guida-frontaliere/tassa-salute-frontalieri/`,
  "speakable": SPEAKABLE_SECTION
@@ -10289,7 +10281,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "author": { "@type": "Organization", "name": "Frontaliere Ticino" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
  "datePublished": "2026-04-22",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-22",
  "inLanguage": "it",
  "mainEntityOfPage": `${BASE_URL}/guida-frontaliere/lamal-frontalieri/`,
  "speakable": SPEAKABLE_SECTION
@@ -10459,7 +10451,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "author": { "@type": "Organization", "name": "Frontaliere Ticino" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
  "datePublished": "2026-04-22",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-22",
  "inLanguage": "it",
  "mainEntityOfPage": `${BASE_URL}/vita-in-ticino/ponti-2026-ticino/`,
  "speakable": SPEAKABLE_SECTION
@@ -10484,7 +10476,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "author": { "@type": "Organization", "name": "Frontaliere Ticino" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
  "datePublished": "2026-04-22",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-22",
  "inLanguage": "it",
  "mainEntityOfPage": `${BASE_URL}/vita-in-ticino/vacanze-scolastiche-ticino-2026/`,
  "speakable": SPEAKABLE_SECTION
@@ -10521,7 +10513,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "author": { "@type": "Organization", "name": "Frontaliere Ticino" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
  "datePublished": "2026-04-23",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-23",
  "inLanguage": "it",
  "mainEntityOfPage": `${BASE_URL}/tasse-e-pensione/tasse-svizzere-frontalieri/`,
  "speakable": SPEAKABLE_SECTION
@@ -10607,7 +10599,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "author": { "@type": "Organization", "name": "Frontaliere Ticino" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
  "datePublished": "2026-04-23",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-23",
  "inLanguage": "it",
  "mainEntityOfPage": `${BASE_URL}/vita-in-ticino/lavoro-a-lugano/`,
  "speakable": SPEAKABLE_SECTION
@@ -10677,7 +10669,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "author": { "@type": "Organization", "name": "Frontaliere Ticino" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
  "datePublished": "2026-04-23",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-23",
  "inLanguage": "it",
  "mainEntityOfPage": `${BASE_URL}/tasse-e-pensione/nuova-legge-frontalieri-2026/`,
  "speakable": SPEAKABLE_SECTION
@@ -10763,7 +10755,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "author": { "@type": "Organization", "name": "Frontaliere Ticino" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
  "datePublished": "2026-04-23",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-23",
  "inLanguage": "it",
  "mainEntityOfPage": `${BASE_URL}/vita-in-ticino/oss-svizzera/`,
  "speakable": SPEAKABLE_SECTION
@@ -10833,7 +10825,7 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  "author": { "@type": "Organization", "name": "Frontaliere Ticino" },
  "publisher": { "@id": "https://frontaliereticino.ch/#organization" },
  "datePublished": "2026-04-23",
- "dateModified": BUILD_DATE_ISO,
+ "dateModified": "2026-04-23",
  "inLanguage": "it",
  "mainEntityOfPage": `${BASE_URL}/statistiche/stipendi-svizzera-vs-italia/`,
  "speakable": SPEAKABLE_SECTION

--- a/services/seoService.ts
+++ b/services/seoService.ts
@@ -383,9 +383,20 @@ async function resolveJobSeoBySlug(
  const canonicalUrl = `${BASE_URL}${canonicalLocalePath}`;
  const address = resolveJobAddress(job);
  const salary = resolveJobSalary(job);
+ // isRemote detection mirrors build-plugins/jobsSeoPagesPlugin.ts's regex so
+ // both paths agree on the same job. Computed BEFORE canonicalInput (rather
+ // than after canonicalSchema, as before) so it can be threaded into the
+ // canonical builder — otherwise buildJobPostingSchema never learns a job is
+ // remote and silently omits `jobLocationType`/`applicantLocationRequirements`
+ // on the SPA path, unlike the SSG path (parity fix).
+ const isRemote = /remote|telelavor|smart[-\s]?working|home office|hybrid/i.test(
+ `${localizedTitle} ${localizedDescription} ${job?.location || ''}`
+ );
  // Delegate to the canonical builder — see
  // build-plugins/shared/jobPostingSchema.ts. This guarantees all 9
- // mandatory JobPosting fields (CLAUDE.md rule #3) with realistic defaults.
+ // mandatory JobPosting fields (CLAUDE.md rule #3) with realistic defaults,
+ // plus industry/occupationalCategory/applicantLocationRequirements when the
+ // source data supports them.
  const canonicalInput: JobInput = {
  id: job?.id,
  slug: job?.slug || cleanSlug,
@@ -409,6 +420,7 @@ async function resolveJobSeoBySlug(
  sector: job?.category,
  category: job?.category,
  url: job?.url,
+ isRemote,
  };
  const canonicalSchema = buildJobPostingSchema(canonicalInput, {
  locale,
@@ -418,9 +430,7 @@ async function resolveJobSeoBySlug(
  // Job-specific FAQPage (build-plugins/shared/jobPostingFaq.ts) — same
  // deterministic template the static SSG plugin uses, so the client-hydrated
  // SPA content matches the prerendered HTML for a client-side navigation to
- // this job (content-parity rule, CLAUDE.md § Static SEO Pages). isRemote
- // detection mirrors build-plugins/jobsSeoPagesPlugin.ts's regex so both
- // paths agree on the same job.
+ // this job (content-parity rule, CLAUDE.md § Static SEO Pages).
  //
  // Canton for the FAQ's G-permit answer MUST use resolveJobCanton (the same
  // resolver JobBoard.tsx uses for its visible accordion, via `detailJobCanton
@@ -433,9 +443,6 @@ async function resolveJobSeoBySlug(
  // city-aware resolution and served the wrong canton's legal border-permit
  // guidance in the FAQ's structured data (review finding on PR #4595).
  const faqCanton = resolveJobCanton(job);
- const isRemote = /remote|telelavor|smart[-\s]?working|home office|hybrid/i.test(
- `${localizedTitle} ${localizedDescription} ${job?.location || ''}`
- );
  const isTicino = faqCanton === 'TI';
  const cantonDisplay = getCantonDisplayName(faqCanton, locale);
  const faqOpts: BuildJobPostingFaqOptions = {

--- a/tests/seo/jobposting-schema.test.ts
+++ b/tests/seo/jobposting-schema.test.ts
@@ -249,6 +249,96 @@ describe('buildJobPostingSchema — out-of-canton job', () => {
   });
 });
 
+describe('buildJobPostingSchema — industry / occupationalCategory (derived from category/sector)', () => {
+  it('emits industry as the raw sector/category text when present', () => {
+    const job: JobInput = {
+      title: 'Infermiere/a',
+      description:
+        'Ruolo infermieristico presso una struttura sanitaria regionale, con turni su reparto e supporto al personale medico.',
+      company: 'Clinica Demo',
+      city: 'Lugano',
+      sector: 'healthcare',
+    };
+    const schema = buildJobPostingSchema(job, OPTS);
+    expect(schema.industry).toBe('healthcare');
+  });
+
+  it('maps a known category to its O*NET-SOC occupationalCategory code', () => {
+    const job: JobInput = {
+      title: 'Software Engineer',
+      description:
+        'Ruolo di sviluppo software full-stack, con focus su TypeScript e React, in un team distribuito.',
+      company: 'Tech SA',
+      city: 'Lugano',
+      category: 'tech',
+    };
+    const schema = buildJobPostingSchema(job, OPTS);
+    expect(schema.occupationalCategory).toBe('15-0000');
+  });
+
+  it('omits industry and occupationalCategory when no category/sector signal exists', () => {
+    const job: JobInput = {
+      title: 'Impiegato',
+      description:
+        'Descrizione generica sufficientemente lunga da superare la soglia minima richiesta dal builder.',
+      company: 'Ditta Anonima',
+      city: 'Lugano',
+    };
+    const schema = buildJobPostingSchema(job, OPTS);
+    expect(schema.industry).toBeUndefined();
+    expect(schema.occupationalCategory).toBeUndefined();
+  });
+
+  it('omits occupationalCategory when the category/sector text is unmapped', () => {
+    const job: JobInput = {
+      title: 'Ruolo generico',
+      description:
+        'Descrizione generica sufficientemente lunga da superare la soglia minima richiesta dal builder.',
+      company: 'Ditta Anonima',
+      city: 'Lugano',
+      category: 'not-a-real-onet-bucket',
+    };
+    const schema = buildJobPostingSchema(job, OPTS);
+    expect(schema.industry).toBe('not-a-real-onet-bucket');
+    expect(schema.occupationalCategory).toBeUndefined();
+  });
+});
+
+// #applicantLocationRequirements: schema.org restricts this property to
+// TELECOMMUTE postings — it must never be stamped on an on-site job.
+describe('buildJobPostingSchema — applicantLocationRequirements scoped to isRemote', () => {
+  it('omits applicantLocationRequirements and jobLocationType for an on-site job', () => {
+    const job: JobInput = {
+      title: 'Magazziniere',
+      description:
+        'Ruolo operativo in magazzino logistico, gestione merci in entrata e uscita, uso muletto.',
+      company: 'Logistica SA',
+      city: 'Lugano',
+      isRemote: false,
+    };
+    const schema = buildJobPostingSchema(job, OPTS);
+    expect(schema.applicantLocationRequirements).toBeUndefined();
+    expect(schema.jobLocationType).toBeUndefined();
+  });
+
+  it('emits applicantLocationRequirements (Country CH) and jobLocationType TELECOMMUTE for a remote job', () => {
+    const job: JobInput = {
+      title: 'Remote Customer Support Agent',
+      description:
+        'Ruolo di supporto clienti da remoto, gestione richieste via chat ed email, orario flessibile.',
+      company: 'Support SA',
+      city: 'Lugano',
+      isRemote: true,
+    };
+    const schema = buildJobPostingSchema(job, OPTS);
+    expect(schema.jobLocationType).toBe('TELECOMMUTE');
+    expect(schema.applicantLocationRequirements).toEqual({
+      '@type': 'Country',
+      name: 'CH',
+    });
+  });
+});
+
 describe('buildJobPostingSchema — required opts', () => {
   it('throws when locale is missing', () => {
     expect(() =>


### PR DESCRIPTION
## Implementato

Bundled fix for all 10 findings from the job-board + article-page SEO/GEO audit (3 High, 4 Medium, 3 Low), executed via 4 parallel worktree-isolated agents + integration.

**High**
- Missing `<meta name="robots">` on 9 hand-rolled SSG job pages in `jobsSeoPagesPlugin.ts` — now emits `index,follow` or `noindex,follow` based on real body word-count vs the 50-word floor (`robotsMetaEnhancedForContent` helper, `build-plugins/constants.ts`).
- **Post-review fix**: reviewer flagged (🔴 Important) that the active-job detail page — one of the 9 sites above — had been given the unconditional `ROBOTS_INDEX_ENHANCED` snippet instead of the gated one; 604/25,386 live jobs have <50-word descriptions and were being indexed as thin content, violating AGENTS.md non-negotiable #4. Switched that one site to `robotsMetaEnhancedForContent`, matching the pattern already used by `jobRecencyPagesPlugin.ts`/`jobSectorPagesPlugin.ts` and correctly leaving the other 8 fixed-prose hub/guide sites (protected by an upstream inventory floor) on the unconditional snippet.
- `JobPosting` schema gaps: added `industry`, `occupationalCategory` (ONET-mapped), and `applicantLocationRequirements` scoped to remote jobs only (was previously either missing or unconditionally hardcoded to `CH`). SPA/SSG parity fix in `services/seoService.ts` (`isRemote` now resolved consistently both sides).
- Article `dateModified` false-freshness: 9 files under `services/seo/seo-blog*.ts` + `seo-pages.ts` declared `BUILD_DATE_ISO = new Date().toISOString()` at module scope — since these modules are dynamically `import()`-ed **client-side** (Vite code-splitting), this executed in the visitor's browser at navigation time, not at build time, so every article showed "just updated" on every visit. Replaced with real per-entry dates; where no source date existed, used `git blame` to find the actual last content-edit date.

**Medium**
- Article author E-E-A-T: `ogPagesPlugin.ts` hardcoded "Valerie Linc" as JSON-LD author on every static article regardless of the real per-article byline shown to visitors — now resolves the real author via `getAuthorBySlug`, matching Google's own guidance that structured data must match visible content.
- `publisher.logo` in article JSON-LD pointed at `/images/logo-192.png`, which 404s live. Now reuses the existing canonical `ORGANIZATION_LD` module (`services/seo/organizationLd.ts`) instead of a drifted hand-rolled duplicate — eliminates the drift class rather than patching the symptom.
- llms.txt / llms-full.txt article coverage expanded from 4-5 curated links to 20, grouped by category; fixed a stale "714+" article count and a latent non-global/comma-unaware regex in `llmsTxtPlugin.ts`.
- `experienceRequirements` / `educationRequirements`: genuinely unavailable from source data — documented as no-op in `jobPostingSchema.ts` docblock rather than fabricated.

**Low**
- Single-image finding: investigated, confirmed genuine structural constraint (no fix applicable, documented).
- Two more findings resolved as part of the above (schema completeness + freshness) with no separate work needed.

**Self-discovered siblings (AGENTS.md #6 sibling-pattern sweep, none in original audit scope):**
- `jobSectorPagesPlugin.ts` and `jobRecencyPagesPlugin.ts` had the identical missing-robots-meta-tag bug as the 9 files above — fixed with the same shared helper.
- `components/community/JobBoard.tsx` hand-rolls its own client-side `JobPosting` JSON-LD and had the same unconditional `applicantLocationRequirements` bug as `jobPostingSchema.ts` — now scoped to `isRemote` only.
- `components/pages/Metodologia.tsx` computed `lastReviewed` via `new Date()` on every render (both in JSON-LD and visible "Ultima revisione" text) — same false-freshness class as the 9 blog files, but live in the browser on every single page view rather than just at deploy time. Replaced with the real last content-edit date (`2026-05-27`, confirmed via `git blame` on the prose).

## Non implementato (ancora)

Nessuno.

**Pre-push sibling-pattern gate (`check-sibling-patterns.mjs --strict`) — full per-file evaluation, pushed with `--no-verify` per AGENTS.md #6 exception clause:**

Surfaced 131 candidate files sharing tokens with this diff. Every file with a `removed:`-literal match (the strongest signal — 4 files) was individually inspected:
- `build-plugins/staticPagesPlugin.ts` (`BUILD_DATE_ISO`): false positive — this is a Vite build plugin (`apply: 'build'`, executes only in `closeBundle()` at real build time on the CI machine), not a client-dynamically-imported module. `new Date()` here IS the real build timestamp; semantically different execution context from the bug class fixed above.
- `build-plugins/weeklyEmployersPlugin.ts` / `relatedSearchClustersPlugin.ts` (guide-title strings): false positive — pre-existing literal string duplication unrelated to the robots-meta bug class; my diff only extracted an inline IIFE to a named const within `jobRecencyPagesPlugin.ts`, the literal content was untouched.
- `build-plugins/seoHubsPlugin.ts` (hardcoded `index,follow`): false positive — these hub pages always render a large fixed prose block (methodology + footer + FAQ, ~2800+ words) regardless of item-list size, so unlike the job-listing pages this fixes, they structurally cannot fall below the 50-word floor.

The remaining ~127 candidates share only generic tokens (`buildJobPostingSchema`, `organizationLd`, `authorProfileService`, `SECTOR_HUB_KEYS`, `clampMetaDescription`, etc.) with no `removed:` match — spot-checked across every distinct category (`components/community/BlogArticles.tsx`, `components/pages/AutorePage.tsx`, `services/seo/seo-authors.ts`, `build-plugins/searchConsoleCompat.ts`, plus a random sample): all are consumers of the same shared/canonical modules this PR touches (e.g. `BlogArticles.tsx`'s `mergeArticleByline` already resolves real per-article authors correctly), not duplicates of any fixed antipattern.

**Second push (post-review fix commit `8b703cb8f2c`) — also `--no-verify`:** re-ran `check-sibling-patterns.mjs --strict` standalone before pushing; it resurfaced the same 141-candidate set (base diff unchanged at 18 files, same `removed:`-literal matches on the same 3 files already dismissed above). Confirmed the new commit's actual added tokens (`robotsMetaEnhancedForContent`, `jobBodyHtml`, `jobRobotsTag`) appear in zero flagged files — this fix introduces no new sibling-pattern surface, it only completes the gating already justified for the 9-site robots-meta bug class.

**Third push (second review's 🔴 fix, commit `42a5bbc00c43`, removing the duplicate client-side `WebPage` JSON-LD on `/metodologia/`) — also `--no-verify`:** re-run surfaced 157 candidates, 17 new vs. the prior push. All 17 individually checked:
- `components/pages/ChiSiamo.tsx` (shares `AboutPage`): false positive, and actually the reference-correct pattern — it has NO inline `<script type="application/ld+json">` at all; the `/about/` AboutPage schema is emitted SSG-only from `seo-pages.ts`'s `'about'` entry, exactly the single-source-of-truth shape this fix moves `/metodologia/` to.
- `components/jobs/EmployerBrandHub.tsx` (shares `dangerouslySetInnerHTML` on real `application/ld+json` scripts, the closest match): false positive — already gated correctly. Its sole SPA mount site (`components/community/JobBoard.tsx:8663`) passes `emitStructuredData={false}` explicitly, so no duplicate/conflicting schema is ever emitted client-side; the component supports emitting its own schema only for contexts with no upstream SSG structured data.
- `JobExpiredView.tsx`, `JobOrphanView.tsx`, `BankComparison.tsx`, `TrafficAlerts.tsx`, `SeasonalNaspiSimulator.tsx`, `PublisherPublishPage.tsx` (share `dangerouslySetInnerHTML`): false positive — all render plain sanitized HTML/prose text, none inject `application/ld+json` scripts; generic React API name match only.
- `services/seo/schema-translators.ts`, `services/seo/page-translations.ts`, `services/seo/inlanguage-whitelist.ts`, `scripts/validate-page-seo-quality.mjs` (share `AboutPage`): false positive — generic schema-type registries/whitelists/validators that handle `AboutPage` as one of many uniform `@type` values, not page-specific duplicate-schema emitters.
- `.github/workflows/generate-article.yml`, `scripts/analyze-webcam-frame.mjs`, `scripts/check-crawler-health.mjs`, `scripts/lib/free-translate.mjs`, `scripts/newsletter-ab-report.mjs` (share literal string `2026-06-16`): false positive — incidental calendar-date co-occurrence unrelated to structured-data freshness (spot-checked `check-crawler-health.mjs`: the date appears in an unrelated comment about historical vacancy counts).

## Test plan

- [x] `tsc --noEmit`: zero errors on all 6 touched files (JobPostingSchema, ogPagesPlugin, seo-blog*/seo-pages, jobsSeoPagesPlugin/jobSectorPagesPlugin/jobRecencyPagesPlugin, JobBoard.tsx, Metodologia.tsx). 197 pre-existing errors elsewhere on origin/main, none in touched files (confirmed unrelated: AI-model fallback tests, job-alert timing, slug-history, job-parser config shapes).
- [x] Targeted vitest suites green: `jobposting-schema`, `search-console-compat`, `jobs-seo-editorial-below-floor-bridge`, `jobs-seo-pages-plugin`, `jobs-seo-title-h1-datemodified`, `job-posting-list-item`, `jobs-seo-pages-plugin-locale-reciprocity`, `job-sector-landing`, `sector-landing-content`, `job-sector-page-weight`, `no-hex-in-seo-plugins`, `seo-completeness`, `article-seo-fallback`, `route-slugs-no-drift`, `static-pages-seo-entry-lookup`, `breadcrumb-coverage`, `job-board-results-loader`, `JobBoard.sticky-sidebar`, `JobBoardFilterAlertCta`.
- [ ] Live post-deploy spot-check: curl a sample job listing page and `/metodologia/` to confirm robots meta + real dates render as expected in production HTML.
