### PR TITLE
feat(ci): extend OmniRoute fallback to every ai-models.mjs consumer workflow

### DIFF
--- a/.github/actions/setup-omniroute/action.yml
+++ b/.github/actions/setup-omniroute/action.yml
@@ -17,19 +17,28 @@ description: >-
   pilot workflow (see generate-company-parser.yml's omniroute_enabled
   input) share one implementation instead of copy-pasted bash drifting
   apart (AGENTS.md #6).
-  Caller MUST run "node scripts/load-rc-env.mjs" before this action so the
-  small curated provider keys are present in env for registration, and MUST
-  gate the `uses:` step itself with an `if:` — this action has no internal
-  opt-in gate of its own (unlike setup-claude-haiku-fallback, which is a
-  default-ON kill-switch); every step here always runs when invoked.
+  Default-ON kill-switch (RC flag ENABLE_OMNIROUTE_FALLBACK='0' disables
+  every step below, mirrors setup-claude-haiku-fallback's ENABLE_HAIKU_
+  ARTICLE_FALLBACK gate) added when this action was rolled out from the two
+  original pilot callers to every other workflow that runs an ai-models.mjs
+  consumer script — a single RC flip now kills OmniRoute registration
+  everywhere at once without editing each caller.
+  Caller MUST run "node scripts/load-rc-env.mjs" before this action so both
+  the kill-switch flag and the small curated provider keys are present in
+  env. Callers that still want a narrower, explicit opt-in (e.g. a
+  workflow_dispatch boolean) keep gating the `uses:` step itself with their
+  own `if:` on top — this action's internal gate is additive, not a
+  replacement.
 runs:
   using: "composite"
   steps:
     - name: Install OmniRoute
+      if: env.ENABLE_OMNIROUTE_FALLBACK != '0'
       shell: bash
       run: OMNIROUTE_SKIP_POSTINSTALL=1 npm install -g omniroute
 
     - name: Start OmniRoute server
+      if: env.ENABLE_OMNIROUTE_FALLBACK != '0'
       shell: bash
       run: |
         OMNI_PW="$(openssl rand -hex 20)"
@@ -48,9 +57,25 @@ runs:
         exit 1
 
     - name: Register OmniRoute providers (small curated set)
+      if: env.ENABLE_OMNIROUTE_FALLBACK != '0'
       shell: bash
       run: node scripts/ci/omniroute-poc-register.mjs
 
     - name: Enable OmniRoute for the rest of this job
+      if: env.ENABLE_OMNIROUTE_FALLBACK != '0'
       shell: bash
       run: echo "OMNIROUTE_ENABLED=1" >> "$GITHUB_ENV"
+
+    # Unconditional (no `if:`) so it also fires when the steps above got
+    # skipped — surfaces flag/registration desync directly in this run's
+    # log instead of requiring a forensic dig through job.steps[].conclusion.
+    - name: Diagnose OmniRoute fallback state
+      shell: bash
+      run: |
+        echo "ENABLE_OMNIROUTE_FALLBACK=${ENABLE_OMNIROUTE_FALLBACK:-<unset>}"
+        echo "OMNIROUTE_ENABLED=${OMNIROUTE_ENABLED:-<unset>}"
+        if command -v omniroute >/dev/null 2>&1; then
+          echo "omniroute CLI: present"
+        else
+          echo "omniroute CLI: NOT on PATH — fallback will no-op if the runtime gate offers it this run"
+        fi

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -62,6 +62,12 @@ jobs:
       - name: Load secrets from Remote Config
         run: node scripts/load-rc-env.mjs
 
+      # ── OmniRoute (ON by default, RC kill-switch ENABLE_OMNIROUTE_FALLBACK='0')
+      # Self-hosted local AI gateway, offered in ai-models.mjs's DEFAULT_CHAIN
+      # as AI_MODELS.OMNIROUTE_AUTO. See
+      # .github/actions/setup-omniroute/action.yml for the full rationale.
+      - uses: ./.github/actions/setup-omniroute
+
       # ── Claude CLI Haiku fallback (ON by default, kill-switch '0') ──────
       # Absolute last resort in ai-models.mjs's DEFAULT_CHAIN, reached only
       # after every free-tier model has failed. See

--- a/.github/workflows/batch-faq-articles.yml
+++ b/.github/workflows/batch-faq-articles.yml
@@ -62,6 +62,12 @@ jobs:
       - name: Load RC secrets
         run: node scripts/load-rc-env.mjs
 
+      # ── OmniRoute (ON by default, RC kill-switch ENABLE_OMNIROUTE_FALLBACK='0')
+      # Self-hosted local AI gateway, offered in ai-models.mjs's DEFAULT_CHAIN
+      # as AI_MODELS.OMNIROUTE_AUTO. See
+      # .github/actions/setup-omniroute/action.yml for the full rationale.
+      - uses: ./.github/actions/setup-omniroute
+
       # ── Claude CLI Haiku fallback (ON by default, kill-switch '0') ──────
       # Absolute last resort in ai-models.mjs's DEFAULT_CHAIN, reached only
       # after every free-tier model has failed. See

--- a/.github/workflows/crawler-group-01.yml
+++ b/.github/workflows/crawler-group-01.yml
@@ -55,6 +55,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run coop
         id: crawler-coop

--- a/.github/workflows/crawler-group-02.yml
+++ b/.github/workflows/crawler-group-02.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run roche
         id: crawler-roche

--- a/.github/workflows/crawler-group-03.yml
+++ b/.github/workflows/crawler-group-03.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run felfel
         id: crawler-felfel

--- a/.github/workflows/crawler-group-04.yml
+++ b/.github/workflows/crawler-group-04.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run lidl
         id: crawler-lidl

--- a/.github/workflows/crawler-group-05.yml
+++ b/.github/workflows/crawler-group-05.yml
@@ -55,6 +55,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run klinik-schuetzen
         id: crawler-klinik-schuetzen

--- a/.github/workflows/crawler-group-06.yml
+++ b/.github/workflows/crawler-group-06.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run merian-iselin
         id: crawler-merian-iselin

--- a/.github/workflows/crawler-group-07.yml
+++ b/.github/workflows/crawler-group-07.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run spital-emmental
         id: crawler-spital-emmental

--- a/.github/workflows/crawler-group-08.yml
+++ b/.github/workflows/crawler-group-08.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run salina-reha
         id: crawler-salina-reha

--- a/.github/workflows/crawler-group-09.yml
+++ b/.github/workflows/crawler-group-09.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run solina
         id: crawler-solina

--- a/.github/workflows/crawler-group-10.yml
+++ b/.github/workflows/crawler-group-10.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run jumbo
         id: crawler-jumbo

--- a/.github/workflows/crawler-group-11.yml
+++ b/.github/workflows/crawler-group-11.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run rehab-basel
         id: crawler-rehab-basel

--- a/.github/workflows/crawler-group-12.yml
+++ b/.github/workflows/crawler-group-12.yml
@@ -55,6 +55,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run klinik-sgm
         id: crawler-klinik-sgm

--- a/.github/workflows/crawler-group-13.yml
+++ b/.github/workflows/crawler-group-13.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run pwc
         id: crawler-pwc

--- a/.github/workflows/crawler-group-14.yml
+++ b/.github/workflows/crawler-group-14.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run spruengli
         id: crawler-spruengli

--- a/.github/workflows/crawler-group-15.yml
+++ b/.github/workflows/crawler-group-15.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run kronenhof
         id: crawler-kronenhof

--- a/.github/workflows/crawler-group-16.yml
+++ b/.github/workflows/crawler-group-16.yml
@@ -55,6 +55,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run ksgr
         id: crawler-ksgr

--- a/.github/workflows/crawler-group-17.yml
+++ b/.github/workflows/crawler-group-17.yml
@@ -55,6 +55,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run siemens-healthineers
         id: crawler-siemens-healthineers

--- a/.github/workflows/crawler-group-18.yml
+++ b/.github/workflows/crawler-group-18.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run tertianum
         id: crawler-tertianum

--- a/.github/workflows/crawler-group-19.yml
+++ b/.github/workflows/crawler-group-19.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run migros
         id: crawler-migros

--- a/.github/workflows/crawler-group-20.yml
+++ b/.github/workflows/crawler-group-20.yml
@@ -55,6 +55,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run ottos
         id: crawler-ottos

--- a/.github/workflows/crawler-group-21.yml
+++ b/.github/workflows/crawler-group-21.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run orell-fuessli-thalia
         id: crawler-orell-fuessli-thalia

--- a/.github/workflows/crawler-group-22.yml
+++ b/.github/workflows/crawler-group-22.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run rittmeyer
         id: crawler-rittmeyer

--- a/.github/workflows/crawler-group-23.yml
+++ b/.github/workflows/crawler-group-23.yml
@@ -57,6 +57,7 @@ jobs:
         run: |-
           node scripts/load-rc-env.mjs
           echo "GH_TOKEN=$GH_TOKEN" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-omniroute
       - uses: ./.github/actions/setup-claude-haiku-fallback
       - name: Run rituals-cosmetics
         id: crawler-rituals-cosmetics

--- a/.github/workflows/generate-article.yml
+++ b/.github/workflows/generate-article.yml
@@ -99,6 +99,12 @@ jobs:
       - name: Load secrets from Remote Config
         run: node scripts/load-rc-env.mjs
 
+      # ── OmniRoute (ON by default, RC kill-switch ENABLE_OMNIROUTE_FALLBACK='0')
+      # Self-hosted local AI gateway, offered in ai-models.mjs's DEFAULT_CHAIN
+      # as AI_MODELS.OMNIROUTE_AUTO. See
+      # .github/actions/setup-omniroute/action.yml for the full rationale.
+      - uses: ./.github/actions/setup-omniroute
+
       # ── Claude CLI Haiku fallback (ON by default, kill-switch '0') ──────
       # Absolute last resort, reached only after every free-tier model AND the
       # local/ollama fallback above have failed. Owner request 2026-07-11: the

--- a/.github/workflows/publish-journalist-articles.yml
+++ b/.github/workflows/publish-journalist-articles.yml
@@ -63,7 +63,18 @@ jobs:
       - name: Load secrets from Remote Config
         run: node scripts/load-rc-env.mjs
 
+      # publish-journalist-article.mjs imports registerArticleFiles/
+      # translateArticle from create-article.mjs, which routes callLLM
+      # through ai-models.mjs's DEFAULT_CHAIN — same AI-fallback wiring as
+      # generate-article.yml (both write via create-article.mjs). Missing
+      # here before this change; added as part of the OmniRoute rollout to
+      # every ai-models.mjs consumer workflow.
+      - uses: ./.github/actions/setup-omniroute
+      - uses: ./.github/actions/setup-claude-haiku-fallback
+
       - name: Publish queued journalist articles
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: node scripts/publish-journalist-article.mjs
 
       - name: Check live internal links of published journalist articles

--- a/.github/workflows/send-newsletter.yml
+++ b/.github/workflows/send-newsletter.yml
@@ -113,6 +113,12 @@ jobs:
       - name: Load secrets from Remote Config
         run: node scripts/load-rc-env.mjs
 
+      # ── OmniRoute (ON by default, RC kill-switch ENABLE_OMNIROUTE_FALLBACK='0')
+      # Self-hosted local AI gateway, offered in ai-models.mjs's DEFAULT_CHAIN
+      # as AI_MODELS.OMNIROUTE_AUTO. See
+      # .github/actions/setup-omniroute/action.yml for the full rationale.
+      - uses: ./.github/actions/setup-omniroute
+
       # ── Claude CLI Haiku fallback (ON by default, kill-switch '0') ──────
       # Same mechanism as generate-article.yml: absolute last resort in
       # NEWSLETTER_AI_CHAIN (scripts/send-newsletter.mjs), reached only after

--- a/.github/workflows/smoke-test-ai-models.yml
+++ b/.github/workflows/smoke-test-ai-models.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Load secrets from Remote Config
         run: node scripts/load-rc-env.mjs
 
+      # ── OmniRoute (ON by default, RC kill-switch ENABLE_OMNIROUTE_FALLBACK='0')
+      # Self-hosted local AI gateway, offered in ai-models.mjs's DEFAULT_CHAIN
+      # as AI_MODELS.OMNIROUTE_AUTO. Wired here too so the smoke-test's
+      # one-ping-per-model sweep actually exercises this tier instead of
+      # silently no-op'ing on it. See
+      # .github/actions/setup-omniroute/action.yml for the full rationale.
+      - uses: ./.github/actions/setup-omniroute
+
       # ── Claude CLI Haiku fallback (ON by default, kill-switch '0') ──────
       # Absolute last resort in ai-models.mjs's DEFAULT_CHAIN, reached only
       # after every free-tier model has failed. Wired here too so the

--- a/.github/workflows/snapshot-jobs-weekly.yml
+++ b/.github/workflows/snapshot-jobs-weekly.yml
@@ -85,6 +85,12 @@ jobs:
         run: node scripts/load-rc-env.mjs
         continue-on-error: true
 
+      # ── OmniRoute (ON by default, RC kill-switch ENABLE_OMNIROUTE_FALLBACK='0')
+      # Self-hosted local AI gateway, offered in ai-models.mjs's DEFAULT_CHAIN
+      # as AI_MODELS.OMNIROUTE_AUTO. See
+      # .github/actions/setup-omniroute/action.yml for the full rationale.
+      - uses: ./.github/actions/setup-omniroute
+
       # ── Claude CLI Haiku fallback (ON by default, kill-switch '0') ──────
       # Absolute last resort in ai-models.mjs's DEFAULT_CHAIN, reached only
       # after every free-tier model has failed. See

--- a/scripts/generate-crawler-group-workflows.mjs
+++ b/scripts/generate-crawler-group-workflows.mjs
@@ -470,6 +470,19 @@ function buildGroupWorkflowObject(groupIndex, group, needsPlaywright, needsIgnor
     ].join('\n'),
   });
 
+  // OmniRoute (ON by default, RC kill-switch ENABLE_OMNIROUTE_FALLBACK='0')
+  // — self-hosted local AI gateway, offered in ai-models.mjs's DEFAULT_CHAIN
+  // as AI_MODELS.OMNIROUTE_AUTO, sorted below the direct free-tier providers
+  // and LOCAL_FALLBACK, above CLAUDE_CLI_HAIKU. Shared composite action: see
+  // .github/actions/setup-omniroute/action.yml for the full rationale +
+  // incident history. Must run before the per-crawler steps below so
+  // OMNIROUTE_ENABLED is set in $GITHUB_ENV in time for every background
+  // step to inherit it (no per-step env: needed — GITHUB_ENV writes made by
+  // a synchronous step before the loop are visible to every subsequent
+  // background step in the same job, same mechanism the RC kill-switch flag
+  // itself relies on below).
+  steps.push({ uses: './.github/actions/setup-omniroute' });
+
   // Claude CLI Haiku fallback (ON by default, kill-switch '0') — absolute
   // last resort in ai-models.mjs's DEFAULT_CHAIN, reached only after every
   // free-tier model has failed. Shared composite action: see

--- a/scripts/load-rc-env.mjs
+++ b/scripts/load-rc-env.mjs
@@ -200,6 +200,13 @@ const RC_TO_ENV = {
   // scripts/ci/omniroute-poc-register.mjs to register the full provider set
   // into a fresh CI OmniRoute instance instead of the small hardcoded list.
   OMNIROUTE_PROVIDERS_JSON:       ['OMNIROUTE_PROVIDERS_JSON'],
+
+  // Global kill-switch for .github/actions/setup-omniroute (default ON —
+  // set this RC flag to '0' to disable OmniRoute registration across every
+  // workflow that includes the composite action, without editing each one).
+  // Unset in RC by default (the action treats unset the same as any value
+  // other than '0': proceed).
+  ENABLE_OMNIROUTE_FALLBACK:      ['ENABLE_OMNIROUTE_FALLBACK'],
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Implementato

- `.github/actions/setup-omniroute/action.yml`: gated all 4 existing steps behind `if: env.ENABLE_OMNIROUTE_FALLBACK != '0'` (default-ON, RC kill-switch — mirrors `setup-claude-haiku-fallback`'s established pattern) + added an unconditional 5th "Diagnose OmniRoute fallback state" step. This makes it safe to invoke unconditionally from any caller without per-caller opt-in gating.
- `scripts/load-rc-env.mjs`: added `ENABLE_OMNIROUTE_FALLBACK` to `RC_TO_ENV` (left unset in Remote Config — default behavior stays "proceed" everywhere until a human explicitly flips it to `'0'`).
- Wired `- uses: ./.github/actions/setup-omniroute` immediately before the existing `setup-claude-haiku-fallback` step in: `analytics.yml`, `batch-faq-articles.yml`, `generate-article.yml`, `snapshot-jobs-weekly.yml`, `send-newsletter.yml`, `smoke-test-ai-models.yml`.
- `publish-journalist-articles.yml`: wired BOTH `setup-omniroute` and `setup-claude-haiku-fallback` — this workflow transitively depends on `ai-models.mjs` via `create-article.mjs` (`registerArticleFiles`/`translateArticle`) but had neither fallback wired before this PR. Same class of gap as the other six files, fixed here per AGENTS.md #6 (fix the whole class in one PR).
- `scripts/generate-crawler-group-workflows.mjs`: inserted the `setup-omniroute` step into `buildGroupWorkflowObject`, immediately before the existing `setup-claude-haiku-fallback` push — the single source-of-truth generator for all 23 `crawler-group-*.yml` files.
- Regenerated all 23 `crawler-group-01.yml`…`crawler-group-23.yml` via `node scripts/generate-crawler-group-workflows.mjs` (verified: exactly 1 line added per file).
- `AI_MODELS.OMNIROUTE_AUTO` was already present in `ai-models.mjs`'s `DEFAULT_CHAIN`, gated by `OMNIROUTE_ENABLED` — zero changes needed to `ai-models.mjs` itself.
- Tests: targeted `npx vitest run tests/load-rc-env-mask-gate.test.ts tests/generate-crawler-group-workflows.test.ts tests/close-recovered-failure-issues-crawler-groups.test.ts` — 34/34 green.
- All 31 changed YAML files validated as parseable via `yaml.safe_load`.
- GitNexus `detect_changes(scope:"all")`: 0 changed symbols, risk_level low (pure CI-wiring change, no function signature touched).

## Non implementato (ancora)

Nessuno.

Sibling-pattern check (`check-sibling-patterns.mjs`) surfaced 16 candidates. Individually inspected each — all false positives, no code change needed:

- `scripts/lib/ai-models.mjs` — falso positivo: è la definizione sorgente delle costanti condivise (CLAUDE_CLI_HAIKU/LOCAL_FALLBACK/OMNIROUTE_AUTO/OMNIROUTE_ENABLED), non un workflow CI da wire-are.
- `scripts/create-article.mjs` — falso positivo: libreria condivisa importata da `generate-article.yml` e `publish-journalist-articles.yml`, entrambi già wired in questa PR; non ha un proprio entry point CI indipendente.
- `.github/workflows/generate-company-parser.yml` — falso positivo: già pilot caller esistente di `setup-omniroute` (pre-esistente a questa PR), nessun gap.
- `.github/workflows/omniroute-poc.yml` — falso positivo: già pilot caller originale del POC, nessun gap.
- `scripts/publish-journalist-article.mjs` — falso positivo: script eseguito da `publish-journalist-articles.yml`, già wired in questa PR; lo script stesso non è un entry point CI separato.
- `services/journalistTypes.ts` — falso positivo: solo type definitions TypeScript, non uno script eseguibile/CI.
- `scripts/batch-add-faq-to-articles.mjs` — falso positivo: script eseguito da `batch-faq-articles.yml`, già wired in questa PR.
- `scripts/ci/omniroute-poc-register.mjs` — falso positivo: invocato DALLA composite action `setup-omniroute` stessa (step "Register OmniRoute providers"), non un caller indipendente da wire-are.
- `scripts/eval-local-rewrite-llm.mjs` — falso positivo: nessun workflow CI lo invoca (grep su `.github/workflows/` zero match) — script locale/manuale, fuori scope CI.
- `scripts/generate-border-wait-ranking-article.mjs` — falso positivo: ha un caller CI (`generate-border-wait-ranking-weekly.yml`) ma lo script stesso non contiene alcun riferimento a `callLLM`/`ai-models.mjs` — non consuma la catena AI centralizzata, nulla da wire-are.
- `scripts/generate-events-digest-article.mjs` — falso positivo: stesso caso, caller CI (`crawl-events.yml`) ma zero riferimenti a `callLLM`/`ai-models.mjs` nello script.
- `scripts/omniroute-diagnose.mjs` — falso positivo: invocato solo da `generate-company-parser.yml` e `omniroute-poc.yml`, entrambi già pilot wired; nessun gap nuovo.
- `scripts/send-newsletter.mjs` — falso positivo: script eseguito da `send-newsletter.yml`, già wired in questa PR.
- `scripts/sync-omniroute-providers-rc.mjs` — falso positivo: nessun workflow CI lo invoca (tool manuale di sync Remote Config da PR #4814), fuori scope CI.
- `services/seo/article-translations.ts` — falso positivo: zero riferimenti a `callLLM`/`ai-models.mjs`, nessuno script/workflow CI lo importa direttamente.
- `services/seo/schema-translators.ts` — falso positivo: stesso caso, zero riferimenti a `callLLM`/`ai-models.mjs`, nessun caller CI diretto.

`git push --no-verify` usato solo dopo questa valutazione individuale completa di tutti i 16 candidati, come da eccezione AGENTS.md #6.