### PR TITLE
fix(seo): dedupe /correzioni/ WebPage JSON-LD via shared builder

### DIFF
--- a/components/pages/Correzioni.tsx
+++ b/components/pages/Correzioni.tsx
@@ -10,7 +10,7 @@ import {
 } from 'lucide-react';
 import { useNavigation } from '@/services/NavigationContext';
 import correctionsLog from '@/data/corrections-log.json';
-import { ORGANIZATION_LD } from '@/services/seo/organizationLd';
+import { buildCorrezioniSeo } from '@/services/seo/seo-correzioni';
 
 /**
  * Correzioni — /correzioni/ public corrections policy + chronological log.
@@ -73,17 +73,6 @@ function formatDate(iso: string): string {
   }
 }
 
-function resolveLastReviewed(entries: CorrectionEntry[]): string {
-  if (entries.length === 0) {
-    // No corrections yet — anchor freshness on today's date.
-    return new Date().toISOString().slice(0, 10);
-  }
-  const sorted = [...entries].sort((a, b) =>
-    a.date < b.date ? 1 : a.date > b.date ? -1 : 0,
-  );
-  return sorted[0].date.slice(0, 10);
-}
-
 export const Correzioni: React.FC = () => {
   const nav = useNavigation();
 
@@ -95,29 +84,9 @@ export const Correzioni: React.FC = () => {
     [],
   );
 
-  const lastReviewed = useMemo(
-    () => resolveLastReviewed(log.entries),
-    [],
-  );
-
-  const jsonLd = useMemo(() => {
-    return {
-      '@context': 'https://schema.org',
-      '@type': 'WebPage',
-      name: 'Correzioni — Frontaliere Ticino',
-      url: 'https://frontaliereticino.ch/correzioni/',
-      description:
-        'Politica di correzione pubblica e registro cronologico delle rettifiche pubblicate da Frontaliere Ticino.',
-      inLanguage: 'it',
-      lastReviewed,
-      mainEntity: {
-        '@type': 'CreativeWork',
-        name: 'Politica di correzione di Frontaliere Ticino',
-        about: 'Editorial corrections policy and public log',
-        publisher: ORGANIZATION_LD,
-      },
-    };
-  }, [lastReviewed]);
+  // Same builder used SSG-side for this page's seo-pages.ts entry — keeps
+  // both surfaces identical by construction instead of two drifted schemas.
+  const jsonLd = useMemo(() => buildCorrezioniSeo('it').jsonLd, []);
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8 animate-fade-in">

--- a/services/seo/seo-correzioni.ts
+++ b/services/seo/seo-correzioni.ts
@@ -2,15 +2,19 @@
  * seo-correzioni — SEO metadata builder for the /correzioni/ page.
  *
  * Used by:
- *  - components/pages/Correzioni.tsx (runtime title/meta sync)
- *  - build-plugins/staticPagesPlugin.ts (static HTML generation)
- *  - tests/correzioni-page.test.tsx (assertions on JSON-LD shape)
+ *  - components/pages/Correzioni.tsx (client-rendered JSON-LD)
+ *
+ * NOT used by build-plugins/staticPagesPlugin.ts: that plugin text-parses
+ * services/seo/seo-pages.ts's 'correzioni' entry at build time (regex +
+ * JSON.parse, not a real JS import), so it cannot call this function —
+ * its literal mirrors this builder's shape minus `lastReviewed`. Keep the
+ * two in sync by hand if the schema shape changes; see the comment on
+ * that entry.
  *
  * Returns a stable SEO bundle per locale with a WebPage JSON-LD that
  * includes `lastReviewed` so search engines see freshness signals.
  */
 import correctionsLog from '@/data/corrections-log.json';
-import { ORGANIZATION_LD } from './organizationLd';
 
 const BASE_URL = 'https://frontaliereticino.ch';
 
@@ -81,9 +85,15 @@ export function buildCorrezioniSeo(locale: CorrezioniLocale = 'it'): CorrezioniS
   const jsonLd: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
-    name: TITLE[locale],
+    // WebPage-specific name/description, distinct from the <title>/meta
+    // TITLE/DESCRIPTION above — matches the SSG static literal in
+    // seo-pages.ts's 'correzioni' entry ('it' is the only shipped locale).
+    name: locale === 'it' ? 'Correzioni — Frontaliere Ticino' : TITLE[locale],
     url: canonical,
-    description: DESCRIPTION[locale],
+    description:
+      locale === 'it'
+        ? 'Politica di correzione pubblica e registro cronologico delle rettifiche pubblicate da Frontaliere Ticino.'
+        : DESCRIPTION[locale],
     inLanguage: locale,
     lastReviewed,
     isPartOf: { '@id': `${BASE_URL}/#website` },
@@ -91,7 +101,7 @@ export function buildCorrezioniSeo(locale: CorrezioniLocale = 'it'): CorrezioniS
       '@type': 'CreativeWork',
       name: 'Editorial corrections policy',
     },
-    publisher: ORGANIZATION_LD,
+    publisher: { '@id': `${BASE_URL}/#organization` },
   };
 
   return {

--- a/services/seo/seo-pages.ts
+++ b/services/seo/seo-pages.ts
@@ -10025,6 +10025,13 @@ const SEO_PAGES_METADATA: Record<string, SEOMetadata> = {
  ogTitle: 'Correzioni — Politica di rettifica e registro pubblico',
  ogDescription: 'Come segnaliamo e registriamo le correzioni: SLA 48 ore, tipologie accettate, registro pubblico cronologico.',
  canonicalPath: '/correzioni/',
+ // staticPagesPlugin.ts text-parses this literal at build time (regex +
+ // JSON.parse, not a real JS import) — cannot reference buildCorrezioniSeo()
+ // here. That builder (services/seo/seo-correzioni.ts) mirrors this exact
+ // shape for the client-rendered copy in Correzioni.tsx and additionally
+ // computes `lastReviewed` from the real corrections log, which this static
+ // literal deliberately omits (no safe way to keep it fresh without either
+ // a stale hand-bumped date or the BUILD_DATE_ISO false-freshness bug).
  structuredData: [
  {
  "@context": "https://schema.org",


### PR DESCRIPTION
## Implementato

Follow-up to #4815 (merged): AGENTS.md #6 sibling-pattern sweep for the `/metodologia/` duplicate-JSON-LD fix in that PR surfaced the same bug class on `/correzioni/`, discovered after #4815 had already merged.

- `services/seo/seo-pages.ts`'s SSG-static `structuredData` literal for `/correzioni/` and `components/pages/Correzioni.tsx`'s hand-rolled client-side `<script type="application/ld+json">` had drifted: different `publisher` shape (full embedded `ORGANIZATION_LD` object vs. an `@id` reference) and different top-level structure (`mainEntity`-wrapped vs. flat `about`/`publisher`).
- Unlike `/metodologia/` (where the client script was simply deleted, since nothing locked in its presence), `tests/correzioni-page.test.tsx` explicitly asserts the client-rendered component itself produces a `<script type="application/ld+json">` with a `lastReviewed` value computed from a (mocked) corrections log — so the client copy could not be removed here.
- Instead, wired `Correzioni.tsx` to the existing-but-previously-unused `buildCorrezioniSeo()` builder (`services/seo/seo-correzioni.ts`), so both surfaces share one source of shape (`name`/`description`/`about`/`publisher`) by construction, differing only by the legitimate `lastReviewed` addition on the client side.
- Also fixed a latent bug in `buildCorrezioniSeo()` itself (never exercised end-to-end before this, since nothing called it): its `jsonLd.name`/`jsonLd.description` incorrectly reused the `<title>`/meta-description strings (`TITLE[locale]`/`DESCRIPTION[locale]`) instead of the WebPage-JSON-LD-specific strings already live in the SSG static literal.
- `services/seo/seo-pages.ts`'s `'correzioni'` entry itself is a comment-only change (documents why it can't call `buildCorrezioniSeo()` directly — `staticPagesPlugin.ts` text-parses this file's raw source at build time rather than importing it as real JS, so it can't evaluate a function call).

## Non implementato (ancora)

Nessuno.

**Pre-push sibling-pattern gate (`check-sibling-patterns.mjs --strict`) — pushed with `--no-verify` per AGENTS.md #6 exception clause, full per-file evaluation:**

Base diff is 3 files (isolated cherry-pick of the fix onto fresh `origin/main`, after #4815 merged mid-fix). Surfaced 16 candidates, none sharing the actual antipattern:
- `scripts/update-stadt-chur-jobs.mjs` (removed `if (entries.length === 0) {`): false positive — unrelated empty-feed guard in a job-sync script (`if (entries.length === 0) { console.log('No jobs found...'); process.exit(0); }`), not the corrections-log freshness logic removed from `Correzioni.tsx`.
- `scripts/lib/border-wait-ranking-content.mjs` (removed `const sorted = [...entries].sort((a, b) =>`): false positive — sorts border-crossing wait-time rows by `avgMinutes`, generic array-sort idiom unrelated to corrections-log date sorting.
- `scripts/send-saved-jobs-digest.mjs` (removed `if (entries.length === 0) {`): false positive — unrelated empty-group guard when batching saved-job digest emails per user, same generic idiom as the first match.
- `build-plugins/ogPagesPlugin.ts` (removed `publisher: ORGANIZATION_LD`): false positive — different, valid, pre-existing pattern: articles get a single SSG-emitted schema plus a client-side dedup-aware sync (`services/seoService.ts`'s `updateStructuredData()`, which skips injecting any `@type` already present statically); no hand-rolled client-side duplicate script exists for articles, so there's no drift risk of the kind fixed here.
- `build-plugins/staticPagesPlugin.ts`, `services/seo/organizationLd.ts`, `services/seoService.ts`, `build-plugins/jobsSeoPagesPlugin.ts`, `build-plugins/shared/jsToJson.ts`, `components/pages/Metodologia.tsx`, `services/seo/seo-authors.ts`: false positive — generic identifier co-occurrence only (`BUILD_DATE_ISO`, `ORGANIZATION_LD`, `organizationLd`, `lastReviewed`), not construct duplication; these are the canonical shared modules/consumers this fix aligns *with*, not siblings exhibiting the same bug.
- `scripts/audit-dist-multi.mjs`, `scripts/validate-structured-data-completeness.mjs`, `services/seo/claim-review.ts`, `services/seo/inlanguage-whitelist.ts`, `services/seo/inlanguage-whitelist.data.mjs`: false positive — share the generic schema.org type string `CreativeWork` only, used as one of many uniform `@type` values in registries/validators, not page-specific duplicate-schema emitters.

## Test plan

- [x] `tsc --noEmit`: zero errors in all 3 touched files (`seo-pages.ts`, `seo-correzioni.ts`, `Correzioni.tsx`).
- [x] `npx vitest run tests/correzioni-page.test.tsx tests/seo-completeness.test.ts tests/static-pages-seo-entry-lookup.test.ts`: 3 files, 51,552 tests, all green.
- [ ] Live post-deploy spot-check: curl `/correzioni/` to confirm the static and client-rendered JSON-LD blocks now match in shape.
