### PR TITLE
fix(static-pages, forms): collapse empty rail gutters, fix PDF field spacing + branding

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1849,6 +1849,20 @@ const App: React.FC = () => {
  setRailsCollapsed((s) => (s.right === allEmpty ? s : { ...s, right: allEmpty }));
  }, []);
 
+ // Same collapse-on-empty behaviour as the SPA rail above, applied to the
+ // staticOverlay 300px rail gutter. `.ft-rail-grid` is build-time HTML
+ // outside #root (build-plugins/shared/railGutters.ts), not a React element,
+ // so the width is driven by direct DOM mutation instead of a style prop.
+ // Scoped out as a follow-up when the SPA rails were fixed — #2830: "300px
+ // blog/job/static reading rails ... left as follow-up" — this closes the
+ // static half of it.
+ useEffect(() => {
+ if (!staticOverlay) return;
+ const grid = document.querySelector<HTMLElement>('.ft-rail-grid');
+ if (!grid) return;
+ grid.style.gridTemplateColumns = `${railsCollapsed.left ? '0px' : '300px'} minmax(0,1fr) ${railsCollapsed.right ? '0px' : '300px'}`;
+ }, [staticOverlay, railsCollapsed]);
+
  return (
  <ErrorBoundary>
  <TabContentContext.Provider value={tabContentValue}>
@@ -2810,8 +2824,8 @@ const App: React.FC = () => {
    if (!leftTarget && !rightTarget) return null;
    return (
  <SafeLazy boundary="rail-ad-static">
- {leftTarget && createPortal(<ArticleRailAdStack side="left" />, leftTarget)}
- {rightTarget && createPortal(<ArticleRailAdStack side="right" />, rightTarget)}
+ {leftTarget && createPortal(<ArticleRailAdStack side="left" onEmptyResolved={handleLeftRailEmpty} />, leftTarget)}
+ {rightTarget && createPortal(<ArticleRailAdStack side="right" onEmptyResolved={handleRightRailEmpty} />, rightTarget)}
  </SafeLazy>
    );
  })()}

--- a/build-plugins/selfCertificationFormsPlugin.ts
+++ b/build-plugins/selfCertificationFormsPlugin.ts
@@ -241,10 +241,12 @@ function drawFooterLogo(doc: PDFKit.PDFDocument, logoPath: string | undefined): 
     const height = width * (80 / 400);
     const x = (PDF_PAGE.width - width) / 2;
     const y = PDF_PAGE.height - 38;
-    doc.opacity(0.55).image(logoPath, x, y, { width, height });
-    doc.opacity(1);
+    doc.opacity(0.55);
+    doc.image(logoPath, x, y, { width, height });
   } catch {
     // Decorative — swallow and continue without the logo.
+  } finally {
+    doc.opacity(1);
   }
 }
 

--- a/build-plugins/selfCertificationFormsPlugin.ts
+++ b/build-plugins/selfCertificationFormsPlugin.ts
@@ -167,10 +167,34 @@ function drawField(doc: PDFKit.PDFDocument, label: string, width?: number): void
   const w = width ?? PDF_CONTENT_WIDTH;
   doc.fontSize(9).font('Helvetica').fillColor(PDF_COLORS.muted);
   doc.text(label, { continued: false });
-  const lineY = doc.y + 14;
+  const lineY = doc.y + 16;
   doc.strokeColor(PDF_COLORS.rule).lineWidth(1);
   doc.moveTo(doc.x, lineY).lineTo(doc.x + w, lineY).stroke();
-  doc.y = lineY + 8;
+  doc.y = lineY + 12;
+}
+
+/**
+ * Two fields side by side sharing one row, e.g. "Nato/a a" + "il (gg/mm/aaaa)".
+ * Replaces the previous pattern of two stacked drawField() calls glued back
+ * together with `doc.y -= 22` — that hack cancelled the vertical advance but
+ * never moved doc.x, so the second label rendered flush under the first
+ * instead of beside it, colliding label text with the line above.
+ */
+function drawFieldRow(doc: PDFKit.PDFDocument, fields: Array<{ label: string; width: number }>, gap = 20): void {
+  const startX = doc.x;
+  const startY = doc.y;
+  doc.fontSize(9).font('Helvetica').fillColor(PDF_COLORS.muted);
+  const labelHeight = Math.max(...fields.map((f) => doc.heightOfString(f.label, { width: f.width })));
+  const lineY = startY + labelHeight + 16;
+  let cursorX = startX;
+  for (const { label, width } of fields) {
+    doc.text(label, cursorX, startY, { width, lineBreak: false });
+    doc.strokeColor(PDF_COLORS.rule).lineWidth(1);
+    doc.moveTo(cursorX, lineY).lineTo(cursorX + width, lineY).stroke();
+    cursorX += width + gap;
+  }
+  doc.x = startX;
+  doc.y = lineY + 12;
 }
 
 /**
@@ -182,10 +206,14 @@ function drawYesNoQuestion(doc: PDFKit.PDFDocument, question: string): void {
   const boxSize = 11;
   const noBoxX = PDF_MARGIN.left + PDF_CONTENT_WIDTH - 40;
   const siBoxX = noBoxX - 62;
+  // Text column stops before the SI box, with a real gutter — the previous
+  // fixed `PDF_CONTENT_WIDTH - 90` budget over-estimated available width by
+  // ~28pt, so long questions ran their last word(s) under the SI checkbox.
+  const textWidth = siBoxX - PDF_MARGIN.left - 16;
   const startY = doc.y;
 
   doc.fontSize(10).font('Helvetica').fillColor(PDF_COLORS.body);
-  doc.text(question, PDF_MARGIN.left, startY, { width: PDF_CONTENT_WIDTH - 90 });
+  doc.text(question, PDF_MARGIN.left, startY, { width: textWidth });
   const textBottomY = doc.y;
 
   doc.strokeColor(PDF_COLORS.rule).lineWidth(1);
@@ -196,10 +224,31 @@ function drawYesNoQuestion(doc: PDFKit.PDFDocument, question: string): void {
   doc.text('NO', noBoxX + boxSize + 4, startY - 1, { width: 24, lineBreak: false });
 
   doc.x = PDF_MARGIN.left;
-  doc.y = Math.max(textBottomY, startY + boxSize) + 10;
+  doc.y = Math.max(textBottomY, startY + boxSize) + 14;
 }
 
-export async function generateSelfCertificationPdf(form: SelfCertFormMeta): Promise<Buffer> {
+/**
+ * Small, low-opacity site wordmark in the footer margin band — a discreet
+ * branding touch, not a header lockup. logo-rect-400.png has dark text on a
+ * transparent background, so it only reads on the page's white background,
+ * never the dark header band. Purely decorative: a missing/corrupt asset
+ * must never break PDF generation, hence the swallowed catch.
+ */
+function drawFooterLogo(doc: PDFKit.PDFDocument, logoPath: string | undefined): void {
+  if (!logoPath) return;
+  try {
+    const width = 84;
+    const height = width * (80 / 400);
+    const x = (PDF_PAGE.width - width) / 2;
+    const y = PDF_PAGE.height - 38;
+    doc.opacity(0.55).image(logoPath, x, y, { width, height });
+    doc.opacity(1);
+  } catch {
+    // Decorative — swallow and continue without the logo.
+  }
+}
+
+export async function generateSelfCertificationPdf(form: SelfCertFormMeta, logoPath?: string): Promise<Buffer> {
   const PDFDocument = (await import('pdfkit')).default;
 
   const doc = new PDFDocument({
@@ -226,10 +275,10 @@ export async function generateSelfCertificationPdf(form: SelfCertFormMeta): Prom
   doc.text('Il/La sottoscritto/a', PDF_MARGIN.left, doc.y, { width: PDF_CONTENT_WIDTH });
   doc.moveDown(0.3);
   drawField(doc, 'Cognome e nome');
-  drawField(doc, 'Nato/a a', 260);
-  doc.y -= 22;
-  drawField(doc, 'il (gg/mm/aaaa)', 200);
-  doc.x = PDF_MARGIN.left;
+  drawFieldRow(doc, [
+    { label: 'Nato/a a', width: 260 },
+    { label: 'il (gg/mm/aaaa)', width: 200 },
+  ]);
   drawField(doc, 'Residente a (comune, via/piazza, n., CAP)');
   drawField(doc, 'Codice fiscale', 260);
 
@@ -277,12 +326,13 @@ export async function generateSelfCertificationPdf(form: SelfCertFormMeta): Prom
     `Documento generato da ${CANONICAL_URL} — non costituisce consulenza legale.`,
     PDF_MARGIN.left, doc.y + 6, { width: PDF_CONTENT_WIDTH },
   );
+  drawFooterLogo(doc, logoPath);
 
   doc.end();
   return bufferPromise;
 }
 
-export async function generateSwissSelfCertificationPdf(form: SwissSelfCertFormMeta): Promise<Buffer> {
+export async function generateSwissSelfCertificationPdf(form: SwissSelfCertFormMeta, logoPath?: string): Promise<Buffer> {
   const PDFDocument = (await import('pdfkit')).default;
 
   const doc = new PDFDocument({
@@ -309,10 +359,10 @@ export async function generateSwissSelfCertificationPdf(form: SwissSelfCertFormM
   doc.text('Candidato/a', PDF_MARGIN.left, doc.y, { width: PDF_CONTENT_WIDTH });
   doc.moveDown(0.3);
   drawField(doc, 'Cognome e nome');
-  drawField(doc, 'Posizione per cui presenta candidatura', 260);
-  doc.y -= 22;
-  drawField(doc, 'Datore di lavoro / azienda', 200);
-  doc.x = PDF_MARGIN.left;
+  drawFieldRow(doc, [
+    { label: 'Posizione per cui presenta candidatura', width: 260 },
+    { label: 'Datore di lavoro / azienda', width: 200 },
+  ]);
 
   doc.moveDown(0.4);
   doc.fontSize(9).font('Helvetica').fillColor(PDF_COLORS.muted);
@@ -346,6 +396,7 @@ export async function generateSwissSelfCertificationPdf(form: SwissSelfCertFormM
     `Riferimento normativo: ${form.legalBasis}. Documento generato da ${CANONICAL_URL} — non costituisce consulenza legale.`,
     PDF_MARGIN.left, PDF_PAGE.height - PDF_MARGIN.bottom - 40, { width: PDF_CONTENT_WIDTH },
   );
+  drawFooterLogo(doc, logoPath);
 
   doc.end();
   return bufferPromise;
@@ -586,11 +637,12 @@ export function selfCertificationFormsPlugin(rootDir: string): Plugin {
       collector.add(path.join(distDir, LANDING_URL_PATH, 'index.html'), html);
       collector.add(path.join(distDir, LANDING_URL_PATH.replace(/\/+$/, '') + '.html'), html);
 
+      const logoPath = path.resolve(rootDir, 'public', 'images', 'publisher', 'logo-rect-400.png');
       const [healthPdf, criminalRecordPdf, chHealthPdf, chCriminalRecordPdf] = await Promise.all([
-        generateSelfCertificationPdf(HEALTH_FORM),
-        generateSelfCertificationPdf(CRIMINAL_RECORD_FORM),
-        generateSwissSelfCertificationPdf(CH_HEALTH_FORM),
-        generateSwissSelfCertificationPdf(CH_CRIMINAL_RECORD_FORM),
+        generateSelfCertificationPdf(HEALTH_FORM, logoPath),
+        generateSelfCertificationPdf(CRIMINAL_RECORD_FORM, logoPath),
+        generateSwissSelfCertificationPdf(CH_HEALTH_FORM, logoPath),
+        generateSwissSelfCertificationPdf(CH_CRIMINAL_RECORD_FORM, logoPath),
       ]);
       fs.mkdirSync(path.join(distDir, 'moduli'), { recursive: true });
       fs.writeFileSync(path.join(distDir, HEALTH_PDF_PATH), healthPdf);

--- a/components/shared/ArticleRailAdStack.tsx
+++ b/components/shared/ArticleRailAdStack.tsx
@@ -51,9 +51,11 @@ export interface ArticleRailAdStackProps {
    * Reports the rail's aggregate fill verdict so the caller can collapse the
    * reserved gutter when nothing fills. Fires `true` only once EVERY mounted
    * panel reports empty (no creative, no AdSense backfill); fires `false` as
-   * soon as any panel fills. Lets the SPA grid drop the 160px track to zero on
-   * an all-empty rail instead of leaving a tall blank column. Omitted on the
-   * static/blog portals, which keep their build-time gutter.
+   * soon as any panel fills. Lets the SPA grid (and, on staticOverlay pages,
+   * the build-time `.ft-rail-grid` gutter, collapsed via direct DOM mutation
+   * in App.tsx) drop the reserved track to zero on an all-empty rail instead
+   * of leaving a tall blank column. Still omitted on the blog portal
+   * (BlogArticles.tsx), which keeps its build-time gutter.
    */
   onEmptyResolved?: (allEmpty: boolean) => void;
   /**


### PR DESCRIPTION
## Implementato

- **Rail gutter collapse su pagine statiche** — `.ft-rail-grid` (moduli, editorial, canton hub, ecc.) riservava sempre 300px per lato anche quando l'ad non riempiva, causando i grossi box vuoti riportati su `/moduli/autocertificazione-candidatura/` (e "molte pagine statiche" per segnalazione utente). Il rail SPA già collassa su empty via `ArticleRailAdStack`'s `onEmptyResolved` (#2830); quella PR aveva esplicitamente scoped-out il rail 300px statico/blog/job come follow-up. Questa PR chiude la metà statica: wiring di `onEmptyResolved` nel mount statico di `App.tsx` + nuovo `useEffect` che collassa `.ft-rail-grid` via mutazione DOM diretta (è HTML build-time fuori da `#root`, non un elemento React — non può usare una style prop).
- **Fix collisione campi PDF autocertificazione** — "Nato/a a" / "il (gg/mm/aaaa)" e "Posizione per cui presenta candidatura" / "Datore di lavoro" usavano un hack `doc.y -= 22` che annullava l'avanzamento verticale senza mai spostare `doc.x`, impilando la seconda label sotto la prima invece che affiancata. Sostituito con un vero helper `drawFieldRow()` che disegna coppie di campi sulla stessa riga.
- **Fix overlap testo/checkbox questionario SI-NO** — `drawYesNoQuestion` usava un budget di larghezza testo fisso (`PDF_CONTENT_WIDTH - 90`) sovrastimato di ~28pt rispetto allo spazio reale prima della checkbox SI, causando testo delle domande lunghe che finiva sotto la checkbox. Larghezza ora derivata dalla posizione reale della checkbox.
- **Spaziatura più ariosa** — margini leggermente aumentati tra label/linea campo e tra domande questionario.
- **Branding discreto nei PDF** — piccolo wordmark (`logo-rect-400.png`, opacità 0.55, ~84px) nel margine footer di tutti e 4 i PDF, centrato, sotto il testo disclaimer. Fallback silenzioso se l'asset manca (branding decorativo, non deve mai rompere la generazione PDF); `doc.opacity(1)` ora ripristinato in un `finally` così un `doc.image()` che lancia non lascia l'opacità a 0.55 per eventuali draw call successive.

Verifica: 15/15 test `tests/self-certification-forms.test.ts` verdi; suite rail-gutter (`dist-static-overlay-rail-ads`, `build-plugins/railGutters`, `build-plugins/handrolled-emitters-rail-gutters`, `regression/static-seo-rail-ads`) verde; `tsc --noEmit` non introduce errori nuovi (baseline pre-esistente invariata, zero hit sui 3 file toccati); GitNexus impact LOW su `generateSelfCertificationPdf`/`generateSwissSelfCertificationPdf`/`ArticleRailAdStack` (solo `closeBundle`/mount esistenti come caller). I 4 PDF sono stati generati e ispezionati visivamente (script isolato via tsx, non build completa) confermando: campi affiancati senza collisione, testo domande non tocca più le checkbox, logo footer visibile e discreto.

`gitnexus_detect_changes` segnala risk "high" perché `App.tsx` è un componente monolitico (5000+ righe in un'unica funzione `App`): qualsiasi edit al suo interno marca l'intera funzione come "touched" e fa scattare fan-out su processi (locale/auth/newsletter-autologin) che il diff non tocca — verificato riga per riga. Impact analysis a livello di simbolo specifico (`ArticleRailAdStackProps`, `generateSelfCertificationPdf`, `generateSwissSelfCertificationPdf`) conferma LOW risk reale.

### Sibling-pattern check (AGENTS.md #6)

Pre-push hook (`check-sibling-patterns.mjs --strict`) ha bloccato il push segnalando 12 file che condividono token con `selfCertificationFormsPlugin.ts`. Grep mirato dell'antipattern reale (`doc.y -=`) su tutto il repo conferma zero occorrenze fuori dal file già corretto. Ispezionati singolarmente — tutti falsi positivi lessicali, nessuno condivide il vero bug (hack di collisione riga / budget larghezza testo sbagliato):

- `build-plugins/pdfWhitepapersPlugin.ts` — pdfkit reale (condivide `pdfKitTheme.ts`), ma layout single-column/TOC (`CONTENT_WIDTH/2` split, blocchi di prosa), nessun field-pairing, nessun `doc.y -=`.
- `build-plugins/shared/pdfKitTheme.ts` — è il modulo che DEFINISCE `PDF_MARGIN`/`PDF_PAGE`, non un sito d'uso.
- `components/calculator/ResultsView.tsx` — usa jsPDF/autoTable, non pdfkit; `fillColor`/`lineWidth` sono chiavi di config autoTable, coincidenza di nome tra librerie diverse.
- `components/guide/BorderMunicipalitiesMap.tsx`, `components/vita/LivabilityMap.tsx`, `components/vita/SupermarketMap.tsx` — `fillColor` è una style-prop standard Leaflet (CircleMarker/Polygon), dominio mappe, non PDF.
- `components/shared/ShareableResultCard.tsx` — `lineWidth` è proprietà Canvas2D (`ctx.lineWidth`), card sharing via canvas, non pdfkit.
- `scripts/audit-dist-multi.mjs`, `scripts/audit-page-weight.mjs` — il match è `inlineBreakdown` (nome funzione), che contiene la sottostringa letterale "lineBreak" — collisione di substring, non l'opzione pdfkit `{lineBreak:false}`.
- `scripts/generate-crawler-group-workflows.mjs` — `lineWidth` è opzione di `YAML.stringify()` (wrapping righe YAML), non stroke width pdfkit.
- `scripts/lib/pdf-job-content.mjs` — il match è `PDF_PAGE_NOISE_PATTERNS` (lista regex per pulizia testo estratto), non l'oggetto geometria pagina `PDF_PAGE`.
- `services/pdfReport.ts` — jsPDF, non pdfkit; stessa coincidenza di nome chiave di `ResultsView.tsx`.

### Adversarial check (review bot) — verificato

- `drawFieldRow` con `lineBreak:false` a width 260 per "Posizione per cui presenta candidatura": misurato via `doc.widthOfString()` a 9pt Helvetica → 155.0pt, ben dentro i 260pt disponibili. Nessun overflow verso "Datore di lavoro / azienda".
- `App.tsx` usa `querySelector('.ft-rail-grid')` (primo match, non `querySelectorAll`): verificato `build-plugins/shared/railGutters.ts` — markup emesso da un'unica costante condivisa (`RAIL_GUTTERS`), un solo `open`/`close` per pagina nei due emitter statici (`htmlTemplate.ts`, `staticPagesPlugin.ts`). Un solo `.ft-rail-grid` per pagina by construction — `querySelector` corretto.
- `doc.opacity(0.55)` senza restore garantito se `doc.image()` lancia: fixato in questo push, vedi bullet branding sopra.

## Non implementato (ancora)

- **Rail gutter collapse su JobBoard/JobOrphanView/JobExpiredView/BlogArticles** — stesso `.ft-rail-grid-x` (300px) riservato fisso, senza `onEmptyResolved`, identico anti-pattern del bug fixato qui per le pagine statiche. Non esteso in questa PR: a differenza del gutter statico (un solo breakpoint xlw, collassato via mutazione DOM) e del rail SPA narrow già fixato in #2830 (un solo breakpoint xlw, collassato via `style` prop), queste 4 superfici hanno **due breakpoint attivi in parallelo** (`xl:max-xlw:grid-cols-[180px_1fr_180px]` + `xlw:grid-cols-[300px_...]`) — un semplice riuso del pattern esistente romperebbe la fascia intermedia 180px, perché uno `style` inline sovrascrive `gridTemplateColumns` a tutti i breakpoint indiscriminatamente. Serve un meccanismo a due tier (es. custom properties CSS per tier, o className mutuamente esclusivi via state) che non ho voluto abbozzare sotto pressione su superfici funnel-critical (job board = alto traffico/conversione). Tracciato in follow-up **#4830** con nota di design sul vincolo dei due breakpoint.
