### PR TITLE
fix(ci): OmniRoute/Haiku fallback gates skip when RC flag genuinely unset

### DIFF
--- a/.github/actions/setup-claude-haiku-fallback/action.yml
+++ b/.github/actions/setup-claude-haiku-fallback/action.yml
@@ -9,21 +9,37 @@ description: >-
   subscription token already used by pr-review-loop.yml/issue-fix.yml), never
   ANTHROPIC_API_KEY.
   Caller MUST run "node scripts/load-rc-env.mjs" before this action so
-  env.ENABLE_HAIKU_ARTICLE_FALLBACK reflects Remote Config (the `if:` below
-  reads ONLY env.*, never vars.* — an unset `vars` context coerces to
-  null->0 in GitHub Actions' comparison, which silently desyncs the install
-  step from the runtime gate; see generate-article.yml git history, run
-  29676088799). Caller MUST also pass CLAUDE_CODE_OAUTH_TOKEN (sourced from
-  secrets.CLAUDE_CODE_OAUTH_TOKEN) via env: on any step that actually invokes
-  callLLM — ai-models.mjs only offers the
-  model when both the flag AND the token are present
+  env.ENABLE_HAIKU_ARTICLE_FALLBACK reflects Remote Config. Caller MUST also
+  pass CLAUDE_CODE_OAUTH_TOKEN (sourced from secrets.CLAUDE_CODE_OAUTH_TOKEN)
+  via env: on any step that actually invokes callLLM — ai-models.mjs only
+  offers the model when both the flag AND the token are present
   (isClaudeCliFallbackEnabled/hasClaudeCodeOauthToken). Passing the token
   here is harmless even on steps that never reach the fallback tier.
+  CORRECTED CLAIM (was wrong in this file since generate-article.yml run
+  29676088799, propagated into setup-omniroute/action.yml via PR #4816):
+  env.* is NOT immune to the null/unset->0 coercion previously blamed only
+  on vars.* — `if: env.X != '0'` also evaluates FALSE when env.X was never
+  set anywhere (confirmed live: this repo's RC value for
+  ENABLE_HAIKU_ARTICLE_FALLBACK happens to be the explicit string 'true',
+  so this action's gate has never actually exercised the true-unset path in
+  production). Fixed below by resolving the default in bash — where
+  `${ENABLE_HAIKU_ARTICLE_FALLBACK:-1}` unambiguously treats unset as
+  `1` — before the `if:` expression ever sees it, same pattern as
+  setup-omniroute/action.yml and translate-pending.yml's
+  TRANSLATE_ARGOS_FIRST_DISABLE (`!= '1'`) gate.
 runs:
   using: "composite"
   steps:
+    # Unconditional: resolves the RC flag's actual default (proceed) in
+    # bash instead of GitHub Actions' `if:` expression language, which
+    # evaluates a true-unset env.X as equal to '0' rather than as ''. See
+    # the CORRECTED CLAIM note above.
+    - name: Resolve Claude CLI Haiku fallback gate
+      shell: bash
+      run: echo "HAIKU_FALLBACK_GATE=${ENABLE_HAIKU_ARTICLE_FALLBACK:-1}" >> "$GITHUB_ENV"
+
     - name: Setup Claude CLI Haiku fallback
-      if: env.ENABLE_HAIKU_ARTICLE_FALLBACK != '0'
+      if: env.HAIKU_FALLBACK_GATE != '0'
       shell: bash
       run: |
         npm install -g @anthropic-ai/claude-code
@@ -35,7 +51,8 @@ runs:
     - name: Diagnose Claude CLI Haiku fallback state
       shell: bash
       run: |
-        echo "ENABLE_HAIKU_ARTICLE_FALLBACK=${ENABLE_HAIKU_ARTICLE_FALLBACK:-<unset>}"
+        echo "ENABLE_HAIKU_ARTICLE_FALLBACK=${ENABLE_HAIKU_ARTICLE_FALLBACK:-<unset>} (raw RC value)"
+        echo "HAIKU_FALLBACK_GATE=${HAIKU_FALLBACK_GATE:-<unset>} (resolved gate)"
         if command -v claude >/dev/null 2>&1; then
           echo "claude CLI: present ($(claude --version 2>&1 | head -1))"
         else

--- a/.github/actions/setup-omniroute/action.yml
+++ b/.github/actions/setup-omniroute/action.yml
@@ -29,16 +29,40 @@ description: >-
   workflow_dispatch boolean) keep gating the `uses:` step itself with their
   own `if:` on top — this action's internal gate is additive, not a
   replacement.
+  BUG THAT SHIPPED IN PR #4816, FIXED HERE: gating steps directly on
+  `if: env.ENABLE_OMNIROUTE_FALLBACK != '0'` silently skips them whenever
+  the RC param is genuinely absent (not merely empty) — confirmed live on
+  main across every wired workflow (ENABLE_OMNIROUTE_FALLBACK was never in
+  Remote Config, so load-rc-env.mjs never writes it to $GITHUB_ENV, so
+  `env.ENABLE_OMNIROUTE_FALLBACK` is a true-unset key, and GitHub Actions'
+  `!=` comparison then evaluates FALSE against '0', not TRUE — the inverse
+  of what an empty-string operand would do). Same root cause already
+  diagnosed for the `vars.*` context in translate-pending.yml's
+  TRANSLATE_ARGOS_FIRST_DISABLE comment (run history there is the reason
+  that gate reads `!= '1'`, not `!= '0'`); this file previously believed
+  (wrongly) that `env.*` didn't share the `vars.*` quirk. Fix: resolve the
+  default in bash BEFORE the `if:` sees it — `${ENABLE_OMNIROUTE_FALLBACK:-1}`
+  correctly treats a true-unset shell var as `1`, sidestepping the
+  expression-language coercion entirely — then gate on the already-resolved,
+  always-non-empty OMNIROUTE_FALLBACK_GATE var instead of the raw RC var.
 runs:
   using: "composite"
   steps:
+    # Unconditional: resolves the RC flag's actual default (proceed) in
+    # bash instead of GitHub Actions' `if:` expression language, which
+    # evaluates a true-unset env.X as equal to '0' rather than as ''. See
+    # the BUG note above.
+    - name: Resolve OmniRoute fallback gate
+      shell: bash
+      run: echo "OMNIROUTE_FALLBACK_GATE=${ENABLE_OMNIROUTE_FALLBACK:-1}" >> "$GITHUB_ENV"
+
     - name: Install OmniRoute
-      if: env.ENABLE_OMNIROUTE_FALLBACK != '0'
+      if: env.OMNIROUTE_FALLBACK_GATE != '0'
       shell: bash
       run: OMNIROUTE_SKIP_POSTINSTALL=1 npm install -g omniroute
 
     - name: Start OmniRoute server
-      if: env.ENABLE_OMNIROUTE_FALLBACK != '0'
+      if: env.OMNIROUTE_FALLBACK_GATE != '0'
       shell: bash
       run: |
         OMNI_PW="$(openssl rand -hex 20)"
@@ -57,12 +81,12 @@ runs:
         exit 1
 
     - name: Register OmniRoute providers (small curated set)
-      if: env.ENABLE_OMNIROUTE_FALLBACK != '0'
+      if: env.OMNIROUTE_FALLBACK_GATE != '0'
       shell: bash
       run: node scripts/ci/omniroute-poc-register.mjs
 
     - name: Enable OmniRoute for the rest of this job
-      if: env.ENABLE_OMNIROUTE_FALLBACK != '0'
+      if: env.OMNIROUTE_FALLBACK_GATE != '0'
       shell: bash
       run: echo "OMNIROUTE_ENABLED=1" >> "$GITHUB_ENV"
 
@@ -72,7 +96,8 @@ runs:
     - name: Diagnose OmniRoute fallback state
       shell: bash
       run: |
-        echo "ENABLE_OMNIROUTE_FALLBACK=${ENABLE_OMNIROUTE_FALLBACK:-<unset>}"
+        echo "ENABLE_OMNIROUTE_FALLBACK=${ENABLE_OMNIROUTE_FALLBACK:-<unset>} (raw RC value)"
+        echo "OMNIROUTE_FALLBACK_GATE=${OMNIROUTE_FALLBACK_GATE:-<unset>} (resolved gate)"
         echo "OMNIROUTE_ENABLED=${OMNIROUTE_ENABLED:-<unset>}"
         if command -v omniroute >/dev/null 2>&1; then
           echo "omniroute CLI: present"


### PR DESCRIPTION
## Implementato

- `setup-omniroute/action.yml`: added an unconditional "Resolve OmniRoute fallback gate" step that computes `OMNIROUTE_FALLBACK_GATE=${ENABLE_OMNIROUTE_FALLBACK:-1}` in bash, and switched the 4 gated steps (Install/Start/Register/Enable) from `if: env.ENABLE_OMNIROUTE_FALLBACK != '0'` to `if: env.OMNIROUTE_FALLBACK_GATE != '0'`. Diagnose step now prints both the raw RC value and the resolved gate.
- `setup-claude-haiku-fallback/action.yml`: identical fix — added "Resolve Claude CLI Haiku fallback gate" step, switched the gate to the resolved `HAIKU_FALLBACK_GATE` var. Corrected the action's description, which previously (wrongly) claimed `env.*` was immune to the null/unset→0 coercion that `vars.*` has.
- Both action descriptions now document the actual root cause and cite the existing `translate-pending.yml` precedent (`TRANSLATE_ARGOS_FIRST_DISABLE`, `!= '1'`) for the same bug class.

## Root cause (verified live, not inferred)

PR #4816 wired `setup-omniroute` into every `ai-models.mjs` consumer workflow behind `if: env.ENABLE_OMNIROUTE_FALLBACK != '0'`, intended as default-ON (RC absent → proceed). Deep log inspection of `generate-article.yml` run 30328463121 (post-merge) proved this never worked: the step's dumped `env:` block lists `ENABLE_HAIKU_ARTICLE_FALLBACK: true` and `OMNIROUTE_PROVIDERS_JSON: ***` but **no `ENABLE_OMNIROUTE_FALLBACK` line at all** — because that RC param doesn't exist, so `load-rc-env.mjs` never writes it to `$GITHUB_ENV` (by design — `if (!value) { missing++; continue; }`). Only the unconditional Diagnose step ran; Install/Start/Register/Enable were silently skipped in every observed run (`generate-article.yml`, `crawler-group-01.yml`, `crawler-group-02.yml`, `batch-faq-articles.yml`, `publish-journalist-articles.yml`), despite each reporting step-level `success`.

Empirically, GitHub Actions evaluates a **true-unset** `env.X` such that `env.X != '0'` is **FALSE** (behaves as if equal to `'0'`), not `''` as assumed. This repo already hit and documented the same class of bug for the `vars.*` context (`translate-pending.yml:186-189`, `TRANSLATE_ARGOS_FIRST_DISABLE`, fixed there by flipping to a disable-flag checked with `!= '1'`). `setup-claude-haiku-fallback` has the byte-identical construct and has only ever worked in production because `ENABLE_HAIKU_ARTICLE_FALLBACK` happens to carry an explicit RC value of `'true'` — it never actually exercised the true-unset path, so the bug was latent there too.

Fix resolves the default in bash (`${VAR:-1}`) — POSIX parameter expansion unambiguously treats a genuinely-unset shell var as the default — before the value ever reaches a GitHub Actions `if:` expression, sidestepping the coercion entirely. This preserves both RC parameter names/semantics (`'0'` still disables) with zero blast radius on `ai-models.mjs` (`ENABLE_HAIKU_ARTICLE_FALLBACK`'s direct-read gate, and `OMNIROUTE_ENABLED`, are untouched).

Sibling sweep: `grep -rn "!= '0'" .github/` found no other `env.X != '0'`-gated composite/workflow step besides these two (other hits are `steps.*.outputs.*` gates, a different context/mechanism, out of this bug class).

## Test plan

- [x] `npx vitest run tests/scripts/ai-models-omniroute-fallback.test.ts tests/scripts/ai-models-claude-cli-fallback.test.ts` — 18/18 green, unchanged (this PR touches only composite-action YAML, not `ai-models.mjs`).
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` on both changed files — valid YAML.
- [x] GitNexus `detect_changes(scope=all)` — risk `low`, 0 changed symbols (pure YAML/workflow change, no indexed code symbols touched).
- [ ] Live verification post-merge: re-run `generate-article.yml` (or observe next scheduled `crawler-group-*`/`batch-faq-articles.yml`) and grep raw logs for the `##[group]Run OMNIROUTE_SKIP_POSTINSTALL=1 npm install -g omniroute` line to confirm Install actually executes this time — will do immediately after merge, same technique used to find the bug.

## Non implementato (ancora)

Nessuno.