### PR TITLE
feat(newsletter): add OmniRoute to NEWSLETTER_AI_CHAIN fallback

### DIFF
--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -216,6 +216,13 @@ const NEWSLETTER_AI_CHAIN = [
   'gemma-4-26b-a4b-it',         // Google — 14,400 req/day free (Gemma 4 MoE — exact API id)
   'mistral/mistral-small-latest', // Mistral — 1B tokens/month free
   'gemini-2.5-pro',             // Google — 500 req/day free, highest quality fallback
+  // Self-hosted local AI gateway (OmniRoute), same AI_MODELS.OMNIROUTE_AUTO
+  // used by create-article.mjs's DEFAULT_CHAIN. Sits below every free-tier
+  // cloud model above (sortChainByScore) but above the reserved, Max-plan
+  // Claude CLI tier below — mirrors DEFAULT_CHAIN's priority order. Skipped
+  // entirely unless OMNIROUTE_ENABLED is set (see "Setup OmniRoute" step in
+  // send-newsletter.yml) — inert no-op otherwise, so it's safe to always list.
+  'omniroute/auto',
   // Absolute last resort — same AI_MODELS.CLAUDE_CLI_HAIKU used by
   // create-article.mjs's DEFAULT_CHAIN. Routed through the local `claude` CLI
   // using CLAUDE_CODE_OAUTH_TOKEN (Max-plan subscription, $0 marginal cost),


### PR DESCRIPTION
## Implementato
- Inserted `'omniroute/auto'` into `NEWSLETTER_AI_CHAIN` (`scripts/send-newsletter.mjs`), between the free-tier cloud models and `'claude-cli/haiku'` — matches `DEFAULT_CHAIN`'s priority order in `ai-models.mjs` (LOCAL_FALLBACK → OMNIROUTE_AUTO → CLAUDE_CLI_HAIKU).
- Context: `send-newsletter.yml` already runs `setup-omniroute` (install/start/register/enable), confirmed live in run [30333856358](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/30333856358) after the gate fix in #4832 — but the model was never in the newsletter's own chain, so the infra ran for nothing. This closes that gap.

## Non implementato
`check-sibling-patterns --strict` flagged 10 untouched files sharing `OMNIROUTE_AUTO`/`OMNIROUTE_ENABLED`/`sortChainByScore`. Individually assessed, all false positives — none contain a second custom chain missing OmniRoute:

- `scripts/lib/ai-models.mjs` — source-of-truth definition of `OMNIROUTE_AUTO`/`DEFAULT_CHAIN` itself, not a consumer site.
- `.github/workflows/generate-article.yml` — comment only; `create-article.mjs` already gets `OMNIROUTE_AUTO` via `DEFAULT_CHAIN`/`cloudOnlyChain`.
- `scripts/generate-crawler-group-workflows.mjs` — comment only (workflow-YAML generator); generated scripts use `DEFAULT_CHAIN`.
- `.github/workflows/analytics.yml` — comment only; `analytics-report.mjs` uses `DEFAULT_CHAIN`.
- `.github/workflows/batch-faq-articles.yml` — comment only; `batch-add-faq-to-articles.mjs` uses `DEFAULT_CHAIN`.
- `.github/workflows/generate-company-parser.yml` — comment only; `generate-company-parser.mjs` uses `DEFAULT_CHAIN`.
- `.github/workflows/omniroute-poc.yml` — comment only; original POC workflow, no chain array.
- `.github/workflows/send-newsletter.yml` — comment only, in the `setup-omniroute` step docs for this same script — not a second chain site.
- `.github/workflows/smoke-test-ai-models.yml` — comment only; `smoke-test-ai-models.mjs` deliberately pins `chain: [model]` one at a time to isolate each model — adding OmniRoute would defeat that isolation, excluded on purpose.
- `.github/workflows/snapshot-jobs-weekly.yml` — comment only; `enrich-related-search-clusters.mjs` uses `DEFAULT_CHAIN`.

Full repo-wide sweep of every `callLLM()` call site (17 files) confirmed only `NEWSLETTER_AI_CHAIN` had a custom chain missing `OMNIROUTE_AUTO`; `create-article.mjs`'s `cloudOnlyChain` already includes it (only filters `LOCAL_FALLBACK`); `eval-local-rewrite-llm.mjs`'s `[LOCAL_FALLBACK]` pin is intentionally local-only, excluded for the same reason as the smoke test.

## Verifica
- `node --check scripts/send-newsletter.mjs` — syntax OK.
- No test asserts `NEWSLETTER_AI_CHAIN`'s exact contents/length.
- GitNexus `detect_changes` (scope: all): `risk_level: low`, 1 changed symbol (`NEWSLETTER_AI_CHAIN`), 0 affected processes.
- Live re-verification deferred: `send-newsletter.yml`'s schedule sends to real subscribers; `workflow_dispatch` defaults to `mode: test` (single `target_email`, not a real send) so a safe manual trigger is available post-merge if wanted, otherwise the next scheduled run (03:33 UTC daily) will exercise it naturally.
