### PR TITLE
fix(email-worker): fail closed when the pre-forward reads throw

### DIFF
--- a/infra/cloudflare-email-worker/stop-reply-handler.js
+++ b/infra/cloudflare-email-worker/stop-reply-handler.js
@@ -277,6 +277,17 @@ export default {
     let to = '';
     let subject = '';
     let auto = false;
+    // Whether the reads below ALL completed. A partial failure must fail
+    // CLOSED: if `headers.get('subject')` throws after `to` already resolved,
+    // `auto` keeps its `false` default, so isAutoReply never actually ran — and
+    // classifying anyway would send an unexamined message down the STOP path
+    // with `subject: ''`, where classifyStopIntent still reads the body. An
+    // out-of-office footer carrying the word "unsubscribe" would then suppress
+    // a company that never opted out: exactly the bug this filter exists to
+    // prevent, re-entered through a partial-read path. Unreadable headers mean
+    // we cannot know whether this is an automatic response, so we do not guess
+    // — forward only.
+    let readOk = false;
     try {
       from = message.from || '';
       // `message.to` is the SMTP envelope-to (RFC 5321 RCPT TO), not the `To:`
@@ -288,6 +299,7 @@ export default {
       to = extractSenderEmail(message.to);
       subject = (message.headers && message.headers.get && message.headers.get('subject')) || '';
       auto = isAutoReply(message.headers, subject);
+      readOk = true;
     } catch {
       // Unreadable envelope/headers: fall through with the empty defaults and
       // let the forward below still happen. Never classified, never dropped.
@@ -310,7 +322,9 @@ export default {
     const isOutreachAddress = outreachAddress ? to === outreachAddress : !isNewsletterAddress;
 
     try {
-      if (isNewsletterAddress) {
+      if (!readOk) {
+        // Fail closed — see readOk above. Forward untouched, classify nothing.
+      } else if (isNewsletterAddress) {
         await handleNewsletterUnsubscribe({ from, subject, message, env, ctx });
       } else if (isOutreachAddress) {
         await handleOutreachReply({ from, subject, message, env, ctx });

--- a/scripts/lib/stop-reply-detect.mjs
+++ b/scripts/lib/stop-reply-detect.mjs
@@ -78,6 +78,15 @@ export const AUTO_REPLY_SUBJECT_PATTERNS = [
  * "unsubscribe" is classified as a real STOP and suppresses a company that
  * never asked to be removed.
  *
+ * Deliberately SUBJECT-ONLY, and not extended to the body: the two sides fail
+ * in opposite directions. Dropping a real auto-reply costs nothing, but
+ * skipping a genuine STOP means we keep emailing someone who asked us to stop —
+ * a CAN-SPAM/nDSG problem, not a nuisance. A body mention of "out of office" is
+ * ambiguous ("I'll be out of office next week, but unsubscribe me anyway"),
+ * while an "Out of office Re: …" SUBJECT is unambiguously machine-generated. So
+ * the queue side stays narrow on purpose; the Worker, which has the RFC 3834
+ * headers, is where broad detection belongs.
+ *
  * @param {{subject?: string}} parts
  * @returns {boolean}
  */

--- a/tests/cf-email-worker-stop-reply-handler.test.ts
+++ b/tests/cf-email-worker-stop-reply-handler.test.ts
@@ -269,6 +269,37 @@ describe('worker email() — unreadable message', () => {
     await Promise.all(ctx.waited);
     expect(message.forward).toHaveBeenCalledWith('human@example.com');
   });
+
+  it('fails closed: a mid-extraction throw skips classification entirely', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    // `to` resolves fine, then the subject read throws — so isAutoReply never
+    // ran and we do NOT know whether this is an autoresponder. Classifying
+    // anyway would run the STOP patterns over this out-of-office body, whose
+    // footer says "unsubscribe", and suppress a company that never opted out.
+    const message = fakeMessage({
+      from: 'HR <hr@casale.ch>',
+      to: 'valerie@frontaliereticino.ch',
+      subject: 'irrelevant — never read',
+      rawText: 'Sono assente fino ad agosto. To unsubscribe from our updates, click here.',
+    });
+    message.headers = { get: () => { throw new Error('malformed header'); } };
+    const ctx = fakeCtx();
+
+    await worker.email(message, {
+      STOP_SECRET: SECRET,
+      REPLY_TRACK_FN_URL: 'https://fn.example/track',
+      STOP_REPLY_FN_URL: 'https://fn.example/stop',
+      NEWSLETTER_ADDRESS: 'newsletter@frontaliereticino.ch',
+      OUTREACH_ADDRESS: 'valerie@frontaliereticino.ch',
+      FORWARD_TO: 'human@example.com',
+    }, ctx);
+
+    await Promise.all(ctx.waited);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(message.forward).toHaveBeenCalledWith('human@example.com');
+  });
 });
 
 describe('hmacHex (Web Crypto)', () => {


### PR DESCRIPTION
Chiude l'adversarial check di #4855 — un buco che il throw-proofing di quella stessa PR aveva aperto. Non è un residuo cosmetico: il test lo dimostra colpendo davvero gli endpoint di soppressione.

## Implementato

- **Fail closed sulle letture pre-forward.** Se `extractSenderEmail(message.to)` riesce e poi `headers.get('subject')` lancia, il `catch` lasciava `auto` al default `false`: `isAutoReply` non era mai girato, ma la classificazione proseguiva lo stesso con `subject: ''` e `classifyStopIntent` leggeva comunque il body. Un footer out-of-office con dentro "unsubscribe" avrebbe soppresso un'azienda che non ha mai fatto opt-out — la classe esatta che questo filtro esiste per prevenire, rientrata da una via di lettura parziale. Ora un flag `readOk` traccia se TUTTE le letture sono andate a buon fine; in caso contrario si salta la classificazione e si inoltra soltanto. Header illeggibili = non possiamo sapere se è una risposta automatica, quindi non tiriamo a indovinare.
- **Documentato perché il gate lato coda resta solo-subject** (la review lo chiedeva). Le due direzioni non sono simmetriche: scartare un auto-reply non costa nulla, ma saltare uno STOP genuino significa continuare a scrivere a chi ha chiesto di smettere — problema di compliance, non fastidio. Un accenno nel body è ambiguo («I'll be out of office next week, but unsubscribe me anyway»), un SUBJECT «Out of office Re: …» no. Il rilevamento largo sta nel Worker, che ha gli header RFC 3834.

## Non implementato (ancora)

- Nessuno.

Sul 🟡 di #4855 (`functions/src/outreachStopReply.js` assente dalla lista falsi positivi): confermo esplicitamente qui, come chiesto. Condivide `STOP_INTENT_PATTERNS`/`isStopReply`/`extractSenderEmail`, ma è **downstream**, non un gemello: il suo unico chiamante è `stop-reply-handler.js:239`, a valle dello stesso gate `auto` di livello superiore che protegge `outreachReplyTrack.js` — e con questa PR è protetto anche dal caso di lettura parziale. Verificato con grep su tutto il repo: nessun altro path lo raggiunge.

`check-sibling-patterns.mjs --strict` su questa PR: nessun candidato surfacato («nessun costrutto distintivo estratto dalle righe cambiate»), quindi push senza `--no-verify`.

## Test plan

- [x] `npx vitest run tests/cf-email-worker-stop-reply-handler.test.ts tests/stop-reply-detect.test.ts` → 34/34 verdi (22 worker + 12 detect).
- [x] Regressione verificata **negativamente**: rimuovendo la guardia `readOk` il nuovo test fallisce con `expected "vi.fn()" to not be called at all, but actually been called 2 times` — cioè senza il fix vengono colpiti sia reply-track sia STOP-suppression su un body out-of-office. Guardia ripristinata e ri-verificato verde (22/22).
- [ ] Post-merge: `deploy-email-worker.yml` verde (nessuna nuova routing rule in questa PR — solo logica del worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
