### PR TITLE
fix(newsletter): send-time personalization data-quality fixes (#3798)

### DIFF
--- a/.github/workflows/send-hour-impact-report.yml
+++ b/.github/workflows/send-hour-impact-report.yml
@@ -104,6 +104,6 @@ jobs:
                 body,
                 '```',
                 '',
-                `_Auto-posted by the Send-Time Impact Report workflow — [run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}). Cohorts flagged \`n<100\` are still below the significance threshold._`,
+                `_Auto-posted by the Send-Time Impact Report workflow — [run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}). Each comparison above is now a real two-proportion z-test (\`[significant, p=...]\` / \`[not significant, p=...]\`), not a fixed n<100 cutoff._`,
               ].join('\n'),
             });

--- a/functions/src/lib/emailExperimentPostHog.js
+++ b/functions/src/lib/emailExperimentPostHog.js
@@ -52,22 +52,30 @@ export const EMAIL_EXPERIMENT_EVENTS = Object.freeze({
 export const EXPERIMENT_EXCLUDED_PROVIDERS = new Set(['mailtrap']);
 
 /**
- * Read the variant persisted on the SEND doc for (email, campaignId). The send
- * pipeline writes it at `${campaignId}__${email}` (double underscore); the ESP
- * webhooks write their own delivery doc at a different id, so non-Resend opens
- * have no variant of their own — look it up here so email_opened carries it.
- * Never throws.
+ * Read the variant + operator-verification flag persisted on the SEND doc for
+ * (email, campaignId). The send pipeline writes it at `${campaignId}__${email}`
+ * (double underscore); the ESP webhooks write their own delivery doc at a
+ * different id, so non-Resend opens have no variant of their own — look it up
+ * here so email_opened carries it. is_operator_verification is stamped by the
+ * send pipeline for manual QA sends (#3798 sibling-pattern sweep); callers use
+ * it to skip captureEmailEvent(OPENED, ...) for those — same reason
+ * scripts/send-newsletter.mjs's persistDelivery skips the SENT-event capture,
+ * a manual test open isn't real subscriber behavior. Never throws.
  * @param {FirebaseFirestore.DocumentReference} subscriberRef  newsletter_subscribers/{email}
- * @returns {Promise<string|null>}
+ * @returns {Promise<{variant: string|null, isOperatorVerification: boolean}>}
  */
 export async function lookupSentVariant(subscriberRef, campaignId, email) {
   try {
-    if (!subscriberRef || !campaignId || !email) return null;
+    if (!subscriberRef || !campaignId || !email) return { variant: null, isOperatorVerification: false };
     const docId = buildDeliveryDocId(campaignId, email);
     const snap = await subscriberRef.collection('campaign_deliveries').doc(docId).get();
-    return snap.exists ? (snap.data()?.variant || null) : null;
+    const data = snap.exists ? snap.data() : null;
+    return {
+      variant: data?.variant || null,
+      isOperatorVerification: data?.is_operator_verification === true,
+    };
   } catch {
-    return null;
+    return { variant: null, isOperatorVerification: false };
   }
 }
 

--- a/functions/src/lib/preferredSendHour.js
+++ b/functions/src/lib/preferredSendHour.js
@@ -151,7 +151,7 @@ export function computePreferredSendHour(events, now = new Date()) {
  *
  * @param {FirebaseFirestore.DocumentReference} subscriberRef
  * @param {*} FieldValue admin.firestore.FieldValue
- * @returns {Promise<{ updated: boolean, hourUtc?: number|null, sampleCount?: number, strength?: number|null }>}
+ * @returns {Promise<{ updated: boolean, hourUtc?: number|null, sampleCount?: number, strength?: number|null, churned?: boolean }>}
  */
 export async function refreshPreferredSendHour(subscriberRef, FieldValue) {
  try {
@@ -193,19 +193,30 @@ export async function refreshPreferredSendHour(subscriberRef, FieldValue) {
 
   const { hourUtc, sampleCount, strength } = computePreferredSendHour(events);
 
+  // Churn instrumentation (#3798 Fix MEDIO-BASSO #6 — prep for calibrating the
+  // 6h staleness gate above): only counts an actual change between two known
+  // hours, not the first assignment (null → hour) a cold-start subscriber
+  // gets once they clear PREFERRED_SEND_MIN_EVENTS. Feeds a future decision on
+  // whether PREFERRED_SEND_REFRESH_INTERVAL_MS is too short (high churn = the
+  // "preference" is still noisy) or safely longer (low churn = stable).
+  const previousHourUtc = current?.preferred_send_hour_utc ?? null;
+  const churned = previousHourUtc !== null && hourUtc !== null && hourUtc !== previousHourUtc;
+
   // Always write, even if the derived values are identical to what's already
   // stored: preferred_send_updated_at is what resets the staleness-gate
   // window above, so skipping the write on "unchanged" would mean the gate
   // never re-engages and this subscriber keeps paying the full events-query
   // cost on every future event forever.
-  await subscriberRef.set({
+  const update = {
    preferred_send_hour_utc: hourUtc,
    preferred_send_sample_count: sampleCount,
    preferred_send_strength: strength,
    preferred_send_updated_at: FieldValue.serverTimestamp(),
-  }, { merge: true });
+  };
+  if (churned) update.preferred_send_hour_churn_count = FieldValue.increment(1);
+  await subscriberRef.set(update, { merge: true });
 
-  return { updated: true, hourUtc, sampleCount, strength };
+  return { updated: true, hourUtc, sampleCount, strength, churned };
  } catch (err) {
   // Non-critical: webhook delivery should not fail because of this scoring.
   console.warn('[preferredSendHour] refresh failed:', err?.message);

--- a/functions/src/newsletterMailerooWebhookCore.js
+++ b/functions/src/newsletterMailerooWebhookCore.js
@@ -239,8 +239,10 @@ export async function persistMailerooEvent(db, event) {
   }
 
   if (type === 'open') {
-    const variant = await lookupSentVariant(subscriberRef, campaignId, email);
-    await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'maileroo', campaignId, variant });
+    const { variant, isOperatorVerification } = await lookupSentVariant(subscriberRef, campaignId, email);
+    if (!isOperatorVerification) {
+      await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'maileroo', campaignId, variant });
+    }
   }
   return { processed: true, type, email, campaignId };
 }

--- a/functions/src/newsletterMailgunWebhookCore.js
+++ b/functions/src/newsletterMailgunWebhookCore.js
@@ -199,8 +199,10 @@ export async function persistMailgunEvent(db, eventData) {
  }
 
  if (type === 'open') {
- const variant = await lookupSentVariant(subscriberRef, campaignId, email);
+ const { variant, isOperatorVerification } = await lookupSentVariant(subscriberRef, campaignId, email);
+ if (!isOperatorVerification) {
  await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'mailgun', campaignId, variant });
+ }
  }
  return { processed: true, type, email, campaignId };
 }

--- a/functions/src/newsletterMailjetWebhookCore.js
+++ b/functions/src/newsletterMailjetWebhookCore.js
@@ -208,8 +208,10 @@ export async function persistMailjetEvent(db, eventData) {
  }
 
  if (type === 'open') {
- const variant = await lookupSentVariant(subscriberRef, campaignId, email);
+ const { variant, isOperatorVerification } = await lookupSentVariant(subscriberRef, campaignId, email);
+ if (!isOperatorVerification) {
  await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'mailjet', campaignId, variant });
+ }
  }
  return { processed: true, type, email, campaignId };
 }

--- a/functions/src/newsletterResendWebhookCore.js
+++ b/functions/src/newsletterResendWebhookCore.js
@@ -2,7 +2,7 @@ import admin from 'firebase-admin';
 import { Resend } from 'resend';
 import { refreshEngagementScore } from './lib/engagementScore.js';
 import { refreshPreferredSendHour } from './lib/preferredSendHour.js';
-import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from './lib/emailExperimentPostHog.js';
+import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS, lookupSentVariant } from './lib/emailExperimentPostHog.js';
 import { buildDeliveryDocId as buildCanonicalDeliveryDocId, uniqueUnknownFallback } from './lib/deliveryDocId.js';
 import { classifyBounceSeverity, bounceUpdateFields, softBounceRecoveryFields, maybeEscalateSoftBounce } from './lib/bounceClassification.js';
 import { instantReactivationFields } from './lib/subscriberReactivation.js';
@@ -358,7 +358,10 @@ export async function applyResendWebhookEvent(rawEvent, options = {}) {
  }
 
  if (type === 'open') {
+ const { isOperatorVerification } = await lookupSentVariant(subscriberRef, campaignId, email);
+ if (!isOperatorVerification) {
  await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.OPENED, { email, provider: 'resend', campaignId, variant, locale });
+ }
  }
  return { handled: true, email, type, campaignId };
 }

--- a/scripts/lib/newsletter-ab-data.mjs
+++ b/scripts/lib/newsletter-ab-data.mjs
@@ -75,6 +75,11 @@ export async function loadCampaignVariantTotals(db, campaignId) {
   for (const doc of sendSnap.docs) {
     const d = doc.data();
     if (!d.sent_at) continue; // only count real sends
+    // Operator QA sends (send-newsletter.mjs --test, #3798) aren't real
+    // subscriber traffic — same exclusion as report-send-hour-impact.mjs's
+    // aggregate(), since this loader feeds BOTH the A/B report and the send
+    // pipeline's auto-promotion resolver (see module docblock).
+    if (d.is_operator_verification) continue;
     const email = (d.email || doc.ref.parent?.parent?.id || '').toLowerCase();
     if (!email) continue;
     // Count ONLY the canonical send-path doc. Non-Resend webhooks write their
@@ -271,6 +276,9 @@ export async function loadCampaignSegmentReport(db, campaignId, opts = {}) {
   for (const doc of sendSnap.docs) {
     const d = doc.data();
     if (!d.sent_at) continue;
+    // Operator QA sends (#3798) aren't real subscriber traffic — same
+    // exclusion as loadCampaignVariantTotals above.
+    if (d.is_operator_verification) continue;
     const email = (d.email || doc.ref.parent?.parent?.id || '').toLowerCase();
     if (!email) continue;
     // Same canonical-doc dedup as loadCampaignVariantTotals — webhook docs for

--- a/scripts/report-send-hour-impact.mjs
+++ b/scripts/report-send-hour-impact.mjs
@@ -55,8 +55,14 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { twoProportionTest } from '../services/newsletter-ab-stats.mjs';
 
-const SMALL_SAMPLE_THRESHOLD = 100;
+// #3798 Fix MEDIO #4: a fixed n<100 threshold flags plenty of large-but-close
+// comparisons as "significant" and plenty of small-but-decisive ones as noise.
+// Reuse the same two-proportion z-test the subject-line A/B report already
+// relies on (services/newsletter-ab-stats.mjs) — single source of truth for
+// "is this rate difference real" across both reports.
+const SIGNIFICANCE_ALPHA = 0.05;
 const BATCH_PAGE_SIZE = 200;
 const SUBCOLLECTION_CONCURRENCY = 20;
 const DEFAULT_DAYS = 30;
@@ -111,6 +117,28 @@ export function parseSinceArg(raw) {
     && parsed.getUTCDate() === Number(d);
   if (!roundTrips) return { date: null, warning: invalidWarning };
   return { date: parsed, warning: null };
+}
+
+/**
+ * Firestore query floor (sent_at/timestamp >= this). Exported/pure so the
+ * "vanishing baseline" regression (#3798, ALTO #1) has a test: a naive
+ * `sinceDate < cutoffDate ? sinceDate : cutoffDate` floors the query AT
+ * sinceDate once `now - days` drifts past it, which can never fetch anything
+ * the aggregator buckets as "before" sinceDate — the before-segment goes
+ * permanently empty from that day forward. The "before" segment is a fixed
+ * historical baseline, not a rolling window, so anchor its floor to
+ * (sinceDate - days) instead, giving it a stable days-day sample no matter how
+ * far "now" advances.
+ * @param {Date} now
+ * @param {number} days
+ * @param {Date|null} sinceDate
+ * @returns {Date}
+ */
+export function computeQueryFloor(now, days, sinceDate) {
+  const cutoffDate = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  if (!sinceDate) return cutoffDate;
+  const baselineFloor = new Date(sinceDate.getTime() - days * 24 * 60 * 60 * 1000);
+  return baselineFloor < cutoffDate ? baselineFloor : cutoffDate;
 }
 
 /** Thrown when a collectionGroup query needs a Firestore index that doesn't exist. */
@@ -283,35 +311,62 @@ export const pct = (n, d) => (d > 0 ? (100 * n) / d : 0);
  * @param {FirebaseFirestore.QueryDocumentSnapshot[]} eventDocs
  * @param {Date|null} sinceDate - when set, returns { before, after } segments; else { combined }
  */
+function toDateSafe(v) {
+  return typeof v?.toDate === 'function' ? v.toDate() : new Date(v);
+}
+
+// Map<string, Date[]> instead of Set<string> (#3798 edge case): a key only
+// tells us an open/click ever happened for that campaign/alert::email or
+// message_id — crediting a delivery also needs to know WHEN, so it can require
+// occurred >= sent (see hasEventAtOrAfter below).
+function addEventTime(map, key, time) {
+  if (!key) return;
+  if (!map.has(key)) map.set(key, []);
+  map.get(key).push(time);
+}
+
+function hasEventAtOrAfter(map, keys, sentAt) {
+  for (const k of keys) {
+    const times = k && map.get(k);
+    if (times && times.some((t) => t >= sentAt)) return true;
+  }
+  return false;
+}
+
 export function aggregate(deliveryDocs, eventDocs, sinceDate) {
-  // Only newsletter events carry campaign_id (job_alert_subscribers events use
-  // alert_id instead) — collectionGroup('events') pulls from BOTH collections
-  // since they share the subcollection name, so filter to newsletter ones.
-  const openedKeys = new Set();
-  const clickedKeys = new Set();
+  // Newsletter events carry campaign_id; job-alert events (job_alert_subscribers
+  // .../events) carry alert_id instead — collectionGroup('events') pulls from
+  // BOTH collections since they share the subcollection name, so accept either
+  // as the send-side identifier.
+  const openedTimes = new Map();
+  const clickedTimes = new Map();
   for (const doc of eventDocs) {
     const d = doc.data();
-    if (!d || !d.campaign_id) continue; // drops job-alert events (no campaign_id)
+    const groupId = d?.campaign_id || d?.alert_id;
+    if (!d || !groupId) continue;
     if (d.event_type !== 'open' && d.event_type !== 'click') continue;
     const email = normalizeEmail(d.email || doc.ref.parent?.parent?.id || '');
-    const key = `${d.campaign_id}::${email}`;
+    const time = toDateSafe(d.timestamp);
+    const key = `${groupId}::${email}`;
     const msgKey = d.message_id ? `msg::${String(d.message_id)}` : null;
-    if (d.event_type === 'open') {
-      if (email) openedKeys.add(key);
-      if (msgKey) openedKeys.add(msgKey);
-    } else {
-      if (email) clickedKeys.add(key);
-      if (msgKey) clickedKeys.add(msgKey);
-    }
+    const map = d.event_type === 'open' ? openedTimes : clickedTimes;
+    if (email) addEventTime(map, key, time);
+    if (msgKey) addEventTime(map, msgKey, time);
   }
 
   const segments = sinceDate ? { before: newSegment(), after: newSegment() } : { combined: newSegment() };
   let droppedNonCanonical = 0;
   let droppedTransactional = 0;
+  let droppedOperatorVerification = 0;
 
   for (const doc of deliveryDocs) {
     const d = doc.data();
     if (!d || !d.sent_at) continue; // only count real sends, not webhook-only stub docs
+    // Operator QA sends (send-newsletter.mjs --test / send-job-alerts.mjs
+    // ALLOWED_EMAILS, #3798) aren't real subscriber traffic and typically lack a
+    // real campaign/alert id — counting them would contaminate the
+    // immediate/pre-feature bucket with artificial deliveries+engagement.
+    if (d.is_operator_verification) { droppedOperatorVerification++; continue; }
     const email = normalizeEmail(d.email || doc.ref.parent?.parent?.id || '');
     if (!email) continue;
     const campaignId = d.campaign_id || 'unknown';
@@ -327,7 +382,7 @@ export function aggregate(deliveryDocs, eventDocs, sinceDate) {
       ? d.send_time_source
       : IMMEDIATE_LABEL;
 
-    const sentAt = typeof d.sent_at?.toDate === 'function' ? d.sent_at.toDate() : new Date(d.sent_at);
+    const sentAt = toDateSafe(d.sent_at);
     const segmentKey = sinceDate ? (sentAt < sinceDate ? 'before' : 'after') : 'combined';
     const cell = segments[segmentKey][groupKey];
 
@@ -335,13 +390,24 @@ export function aggregate(deliveryDocs, eventDocs, sinceDate) {
 
     const key = `${campaignId}::${email}`;
     const msgKey = d.message_id ? `msg::${String(d.message_id)}` : null;
-    const opened = !!d.opened_at || openedKeys.has(key) || (msgKey && openedKeys.has(msgKey));
-    const clicked = !!d.clicked_at || clickedKeys.has(key) || (msgKey && clickedKeys.has(msgKey));
+    // Edge case (#3798): an open/click can carry a timestamp before this
+    // delivery's sent_at when a send lacking a real campaign/alert id (tag
+    // 'unknown' — confirmation emails, ad-hoc sends) collides with an earlier
+    // send to the same address on the shared 'unknown'-keyed canonical doc, so
+    // sent_at gets overwritten and orphans the older event. Require the event
+    // (own-doc field or events-collection match) to have occurred at or after
+    // sent_at before crediting it to this delivery — strict, no tolerance
+    // window, since the corrected canonical-doc-only data shows zero genuine
+    // sub-10-second cases (see docs/AGENTS-HISTORY.md's #3798 investigation).
+    const openedAtDate = d.opened_at ? toDateSafe(d.opened_at) : null;
+    const clickedAtDate = d.clicked_at ? toDateSafe(d.clicked_at) : null;
+    const opened = (openedAtDate && openedAtDate >= sentAt) || hasEventAtOrAfter(openedTimes, [key, msgKey], sentAt);
+    const clicked = (clickedAtDate && clickedAtDate >= sentAt) || hasEventAtOrAfter(clickedTimes, [key, msgKey], sentAt);
     if (opened) cell.opens++;
     if (clicked) cell.clicks++;
   }
 
-  return { segments, droppedNonCanonical, droppedTransactional };
+  return { segments, droppedNonCanonical, droppedTransactional, droppedOperatorVerification };
 }
 
 // ── Reporting ────────────────────────────────────────────────────────────
@@ -355,9 +421,11 @@ export function formatSegmentTable(title, cells) {
     const c = cells[g];
     const openRate = pct(c.opens, c.deliveries);
     const clickRate = pct(c.clicks, c.deliveries);
-    const smallNote = c.deliveries > 0 && c.deliveries < SMALL_SAMPLE_THRESHOLD ? '  (n<100, not significant)' : '';
+    // No per-row significance note: "significant" is a property of a
+    // COMPARISON between two groups, not of a single group's sample size —
+    // see comparisonLine below, which runs the real test against a baseline.
     lines.push(
-      `  ${g.padEnd(24)} ${String(c.deliveries).padStart(10)}  ${String(c.opens).padStart(7)}  ${openRate.toFixed(1).padStart(8)}%  ${String(c.clicks).padStart(8)}  ${clickRate.toFixed(1).padStart(9)}%${smallNote}`,
+      `  ${g.padEnd(24)} ${String(c.deliveries).padStart(10)}  ${String(c.opens).padStart(7)}  ${openRate.toFixed(1).padStart(8)}%  ${String(c.clicks).padStart(8)}  ${clickRate.toFixed(1).padStart(9)}%`,
     );
   }
   return lines.join('\n');
@@ -373,11 +441,17 @@ export function comparisonLine(label, cellA, cellB, nameA, nameB) {
   const clickRateA = pct(cellA.clicks, cellA.deliveries);
   const clickRateB = pct(cellB.clicks, cellB.deliveries);
   const clickDelta = clickRateA - clickRateB;
-  const smallSampleFlag = (cellA.deliveries < SMALL_SAMPLE_THRESHOLD || cellB.deliveries < SMALL_SAMPLE_THRESHOLD)
-    ? ' [not significant — n<100 in at least one group]'
-    : '';
+  // Real two-proportion z-test on the open rate (primary metric) instead of a
+  // fixed n<100 threshold: a 500-vs-500 comparison with near-identical rates
+  // is genuinely not significant, while a 60-vs-60 comparison with a huge gap
+  // can be — sample size alone answers neither question.
+  const test = twoProportionTest(
+    { sends: cellA.deliveries, opens: cellA.opens },
+    { sends: cellB.deliveries, opens: cellB.opens },
+  );
+  const sigFlag = test ? ` [${test.pValue < SIGNIFICANCE_ALPHA ? 'significant' : 'not significant'}, p=${test.pValue.toFixed(3)}]` : '';
   const sign = (n) => (n >= 0 ? '+' : '');
-  return `${label}: open rate ${sign(openDelta)}${openDelta.toFixed(1)}pp (${rateA.toFixed(1)}% vs ${rateB.toFixed(1)}%), click rate ${sign(clickDelta)}${clickDelta.toFixed(1)}pp (${clickRateA.toFixed(1)}% vs ${clickRateB.toFixed(1)}%)${smallSampleFlag}`;
+  return `${label}: open rate ${sign(openDelta)}${openDelta.toFixed(1)}pp (${rateA.toFixed(1)}% vs ${rateB.toFixed(1)}%), click rate ${sign(clickDelta)}${clickDelta.toFixed(1)}pp (${clickRateA.toFixed(1)}% vs ${clickRateB.toFixed(1)}%)${sigFlag}`;
 }
 
 function printSegment(name, cells) {
@@ -401,8 +475,15 @@ Usage:
   node scripts/report-send-hour-impact.mjs --json
 
 Options:
-  --days <N>       Lookback window in days. Default: 30. Must be > 0.
+  --days <N>       Lookback window in days. Default: 30. Must be > 0. When
+                    --since is set, also sizes the "before" baseline: it
+                    covers the N days immediately preceding --since, anchored
+                    to --since rather than to "now" (see --since).
   --since <DATE>   YYYY-MM-DD. Splits the window into before/on-after this date.
+                    The "before" segment is a FIXED historical baseline (--days
+                    before --since) — it does not slide forward with "now", so
+                    it stays populated indefinitely instead of emptying out
+                    once "now - days" runs past --since (#3798, ALTO #1).
   --json           Emit a single JSON object on stdout instead of the table.
   --help, -h       Show this help.
 
@@ -432,13 +513,13 @@ async function main() {
   }
 
   const now = new Date();
-  const cutoffDate = new Date(now.getTime() - DAYS * 24 * 60 * 60 * 1000);
-  const queryFloor = SINCE_DATE && SINCE_DATE < cutoffDate ? SINCE_DATE : cutoffDate;
+  const queryFloor = computeQueryFloor(now, DAYS, SINCE_DATE);
+  const baselineFloor = SINCE_DATE ? new Date(SINCE_DATE.getTime() - DAYS * 24 * 60 * 60 * 1000) : null;
 
   if (!JSON_OUT) {
     console.log(`\n📬 Send-hour personalization impact report (feature #3798)`);
     console.log(`   Window: last ${DAYS} day(s) — since ${queryFloor.toISOString()}`);
-    if (SINCE_DATE) console.log(`   Pre/post split at: ${SINCE_DATE.toISOString()}`);
+    if (SINCE_DATE) console.log(`   Pre/post split at: ${SINCE_DATE.toISOString()} (before-baseline anchored to ${baselineFloor.toISOString()})`);
     console.log('   Read-only — no Firestore writes, no emails sent.\n');
   }
 
@@ -467,7 +548,7 @@ async function main() {
     process.exit(0);
   }
 
-  const { segments, droppedNonCanonical, droppedTransactional } = aggregate(deliveryDocs, eventDocs, SINCE_DATE);
+  const { segments, droppedNonCanonical, droppedTransactional, droppedOperatorVerification } = aggregate(deliveryDocs, eventDocs, SINCE_DATE);
 
   if (JSON_OUT) {
     console.log(JSON.stringify({
@@ -477,6 +558,7 @@ async function main() {
       usedFallbackQuery: usedFallback,
       droppedNonCanonicalDocs: droppedNonCanonical,
       droppedTransactionalDocs: droppedTransactional,
+      droppedOperatorVerificationDocs: droppedOperatorVerification,
       segments,
     }, null, 2));
     return;
@@ -489,7 +571,7 @@ async function main() {
     printSegment(`Last ${DAYS} day(s)`, segments.combined);
   }
 
-  console.log(`\n(Fallback per-subscriber query used: ${usedFallback ? 'yes' : 'no'}; ${droppedNonCanonical} non-canonical duplicate delivery doc(s) ignored; ${droppedTransactional} transactional (calculator/LAMal) delivery doc(s) excluded.)\n`);
+  console.log(`\n(Fallback per-subscriber query used: ${usedFallback ? 'yes' : 'no'}; ${droppedNonCanonical} non-canonical duplicate delivery doc(s) ignored; ${droppedTransactional} transactional (calculator/LAMal) delivery doc(s) excluded; ${droppedOperatorVerification} operator-verification delivery doc(s) excluded.)\n`);
 }
 
 // Run only when invoked directly (node scripts/report-send-hour-impact.mjs);

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -45,6 +45,7 @@ import { runWithConcurrency, checkPageBodyLive } from './lib/live-link-check.mjs
 import { computeScheduledSendAt, resolveEffectivePreferredHour, perUserSendTimeEnabled, logScheduleDistribution } from './lib/send-schedule.mjs';
 import { resolveEffectiveJobAlertTier, JOB_ALERT_ENGAGEMENT_TIERS } from './lib/jobAlertEngagementTier.mjs';
 import { SLUG_TABLES } from '../services/routeSlugs.data.ts';
+import { buildDeliveryDocId } from '../functions/src/lib/deliveryDocId.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -1093,6 +1094,49 @@ export async function mailerooMetaOnSent(item, sendResult) {
   }
 }
 
+// Job-alert delivery record (#3798 report accuracy): mirrors send-newsletter.mjs's
+// persistDelivery, but keyed by alertId instead of campaignId — writes under
+// job_alert_subscribers/{email}/campaign_deliveries/{buildDeliveryDocId(alertId,
+// email)} so scripts/report-send-hour-impact.mjs's collectionGroup('campaign_deliveries')
+// query (previously job-alert-blind — job alerts only wrote alert_deliveries, a
+// differently-named/shaped subcollection) sees per-user send-time outcomes for
+// job alerts too. Used by both the first-send (sendBatch) and retry
+// (processRetryQueue) paths, same as mailerooMetaOnSent above.
+async function persistJobAlertDelivery(item, sendResult) {
+  const email = item.recipient?.email?.toLowerCase().trim();
+  const alertId = item.meta?.alertId;
+  if (!email || !alertId) return;
+  try {
+    const db = await getFirestoreAdmin();
+    const deliveryDocId = buildDeliveryDocId(alertId, email);
+    await db.collection('job_alert_subscribers').doc(email)
+      .collection('campaign_deliveries').doc(deliveryDocId).set({
+      email,
+      campaign_id: alertId,
+      message_id: sendResult?.messageId || null,
+      provider: sendResult?.provider || null,
+      // Per-user send-time (#3798): scheduledFor is the cascade's authoritative
+      // outcome (null when provider didn't honor/support scheduling), not just
+      // what was requested. sendTimeSource carries WHY it was requested
+      // (personal/global) — absent entirely for retries, which never resolve one.
+      scheduled_for: sendResult?.scheduledFor ?? null,
+      send_time_source: item.meta?.sendTimeSource ?? null,
+      is_operator_verification: !!item.meta?.isOperatorVerification,
+      sent_at: new Date(),
+    }, { merge: true });
+  } catch (e) {
+    console.warn('⚠️ Job-alert delivery persist failed:', e?.message);
+  }
+}
+
+// sendEmailCascade accepts a single onSent callback — compose both post-send
+// side effects here so both call sites (sendBatch, processRetryQueue) wire the
+// same behavior via one named reference.
+async function onSentComposed(item, sendResult) {
+  await mailerooMetaOnSent(item, sendResult);
+  await persistJobAlertDelivery(item, sendResult);
+}
+
 async function sendBatch(emails) {
   // Use cascade for bulk sending
   const { sendEmailCascade, logProviderSummary } = await import('./lib/email-cascade.mjs');
@@ -1124,11 +1168,23 @@ async function sendBatch(emails) {
         ...(e.scheduledAt ? { scheduledAt: e.scheduledAt } : {}),
       },
       recipient: { email: e.to },
-      meta: { type: 'job-alert', alertId: e.alertId, sendTimeSource: e.sendTimeSource || null },
+      meta: {
+        type: 'job-alert',
+        alertId: e.alertId,
+        sendTimeSource: e.sendTimeSource || null,
+        // is_operator_verification (#3798 report accuracy): ALLOWED_EMAILS set means
+        // an operator verification run (parallel send-newsletter.mjs's mode==='test')
+        // targeting specific recipient(s), not real subscriber traffic — flagged so
+        // report-send-hour-impact.mjs can exclude it.
+        isOperatorVerification: !!ALLOWED_EMAILS,
+      },
     };
   });
 
-  const result = await sendEmailCascade(cascadeEmails, { concurrency: 3, onSent: mailerooMetaOnSent });
+  const result = await sendEmailCascade(cascadeEmails, {
+    concurrency: 3,
+    onSent: onSentComposed,
+  });
   logProviderSummary();
 
   // Per-user send-time observability (#3798 follow-up): the cascade returns
@@ -1239,7 +1295,10 @@ async function processRetryQueue(db) {
   // Pass the same onSent so retried emails also write a maileroo_message_meta
   // record — otherwise their open/click webhooks fall back to `skipped` (the exact
   // attribution bug fixed for the first-send path in #1135).
-  const result = await sendEmailCascade(retryEmails, { concurrency: 3, onSent: mailerooMetaOnSent });
+  const result = await sendEmailCascade(retryEmails, {
+    concurrency: 3,
+    onSent: onSentComposed,
+  });
   logProviderSummary();
 
   // Build a set of successfully sent recipient emails for lookup

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -1591,6 +1591,9 @@ async function persistDelivery(recipient, messageId, meta) {
       // stays the moment the API call was made, unchanged.
       scheduled_for: meta.scheduledFor ?? null,
       send_time_source: meta.sendTimeSource ?? null,
+      // Operator QA send (mode==='test', single --target-email) — not real
+      // subscriber traffic; report-send-hour-impact.mjs excludes these.
+      is_operator_verification: meta.isOperatorVerification ?? false,
       sent_at: new Date(),
     }, { merge: true });
     // Maileroo's open/click webhooks carry only message_reference_id (no recipient,
@@ -2364,7 +2367,11 @@ async function main() {
 
     emails.push({
       recipient: subscriber,
-      meta: { campaignId, subject, variant, sendTimeSource, segment: articleContent.segment },
+      // is_operator_verification (#3798 report accuracy): mode==='test' sends go to a
+      // single --target-email for manual QA, not real subscriber traffic — flagged so
+      // report-send-hour-impact.mjs can exclude them instead of miscounting them as
+      // "immediate/pre-feature" sends.
+      meta: { campaignId, subject, variant, sendTimeSource, segment: articleContent.segment, isOperatorVerification: mode === 'test' },
       payload: {
         from: FROM_EMAIL,
         to: [subscriber.email],

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -1630,15 +1630,21 @@ async function persistDelivery(recipient, messageId, meta) {
     }
     // A/B exposure event (no-op unless POSTHOG_EMAIL_EXPERIMENT enabled). Ties to
     // the email_opened conversion in PostHog by distinct_id (email); carries the
-    // variant + provider for the funnel breakdown.
-    await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.SENT, {
-      email,
-      variant: meta.variant,
-      provider: meta.provider,
-      campaignId: meta.campaignId,
-      locale,
-      segment: meta.segment,
-    });
+    // variant + provider for the funnel breakdown. Skipped for operator QA
+    // sends (#3798 sibling-pattern sweep) — same reason is_operator_verification
+    // is excluded from the Firestore campaign_deliveries aggregates: a manual
+    // test send/open isn't real subscriber behavior and would enter the
+    // email_sent→email_opened funnel as a false exposure.
+    if (!meta.isOperatorVerification) {
+      await captureEmailEvent(EMAIL_EXPERIMENT_EVENTS.SENT, {
+        email,
+        variant: meta.variant,
+        provider: meta.provider,
+        campaignId: meta.campaignId,
+        locale,
+        segment: meta.segment,
+      });
+    }
   } catch (e) {
     console.warn('\u26a0\ufe0f Delivery persist failed:', e?.message);
   }

--- a/services/newsletterSubscribers.ts
+++ b/services/newsletterSubscribers.ts
@@ -414,17 +414,6 @@ function buildDeliveryDocId(email: string, campaignId: string): string {
  return `${campaignId}__${normalizeNewsletterEmail(email)}`.replace(/[^a-z0-9@._-]+/gi, '-');
 }
 
-// Events without a campaignId (untagged links, ad-hoc newsletter clicks) must
-// not collapse onto the shared literal 'unknown' — two distinct untagged
-// events for different subscribers would then write the same
-// campaign_deliveries doc, clobbering each other's timestamp fields (#4847
-// class fix, see functions/src/newsletterResendWebhookCore.js). Key the
-// fallback on messageId, unique per send, falling back to the current time
-// only if even that is missing.
-function uniqueUnknownFallback(messageId?: string | null): string {
- return `unknown:${sanitizeString(messageId) || nowIso()}`;
-}
-
 export async function upsertNewsletterDelivery(
  db: Firestore,
  input: NewsletterDeliveryInput,
@@ -645,9 +634,15 @@ export async function recordNewsletterClick(
  },
  { merge: true },
  );
+ if (input.campaignId) {
+ // No fallback id here — a shared 'unknown' doc across unrelated
+ // campaigns would collide clicks onto the same canonical delivery
+ // doc (#3798 sibling sweep, same collision class already fixed on
+ // the send path). Skip the attribution write; upsertNewsletterDelivery
+ // requires a real campaignId anyway.
  await upsertNewsletterDelivery(db, {
  email,
- campaignId: input.campaignId || uniqueUnknownFallback(input.messageId),
+ campaignId: input.campaignId,
  messageId: input.messageId || null,
  variant: input.variant || null,
  locale: input.sourceLocale || null,
@@ -656,6 +651,7 @@ export async function recordNewsletterClick(
  clickedLink: input.targetUrl || input.linkUrl || null,
  clickedLabel: input.linkLabel || null,
  });
+ }
  await recordNewsletterEvent(db, input);
 }
 
@@ -704,9 +700,13 @@ export async function applyNewsletterDeliveryEvent(
  }
 
  await setDoc(doc(collection(db, 'newsletter_subscribers'), email), update, { merge: true });
+ if (input.campaignId) {
+ // Same collision class as recordNewsletterClick above — no 'unknown'
+ // fallback, skip the attribution write instead of colliding on a
+ // shared canonical doc.
  await upsertNewsletterDelivery(db, {
  email,
- campaignId: input.campaignId || uniqueUnknownFallback(input.messageId),
+ campaignId: input.campaignId,
  messageId: input.messageId || null,
  variant: input.variant || null,
  locale: input.sourceLocale || null,
@@ -715,6 +715,7 @@ export async function applyNewsletterDeliveryEvent(
  clickedLink: input.targetUrl || input.linkUrl || null,
  clickedLabel: input.linkLabel || null,
  });
+ }
  await recordNewsletterEvent(db, input);
 }
 

--- a/tests/job-alert-email.test.ts
+++ b/tests/job-alert-email.test.ts
@@ -807,11 +807,23 @@ describe('job alert maileroo meta — open/click attribution writer (#1140)', ()
       path.resolve(__dirname, '../scripts/send-job-alerts.mjs'),
       'utf8',
     );
-    // Both the first-send and retry sendEmailCascade calls must wire mailerooMetaOnSent.
-    const onSentWirings = src.match(/onSent:\s*mailerooMetaOnSent/g) || [];
+    // Both the first-send and retry sendEmailCascade calls must wire the same
+    // composed callback (sendEmailCascade only accepts one onSent).
+    const onSentWirings = src.match(/onSent:\s*onSentComposed/g) || [];
     expect(onSentWirings.length).toBeGreaterThanOrEqual(2);
     // Guard the retry call specifically.
-    expect(src).toMatch(/sendEmailCascade\(retryEmails,\s*\{[^}]*onSent:\s*mailerooMetaOnSent/s);
+    expect(src).toMatch(/sendEmailCascade\(retryEmails,\s*\{[^}]*onSent:\s*onSentComposed/s);
+  });
+
+  it('onSentComposed wires both maileroo meta persist and #3798 delivery persist', () => {
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../scripts/send-job-alerts.mjs'),
+      'utf8',
+    );
+    const fnMatch = src.match(/async function onSentComposed\(item, sendResult\) \{([\s\S]*?)\n\}/);
+    expect(fnMatch).not.toBeNull();
+    expect(fnMatch[1]).toMatch(/mailerooMetaOnSent\(item, sendResult\)/);
+    expect(fnMatch[1]).toMatch(/persistJobAlertDelivery\(item, sendResult\)/);
   });
 });
 

--- a/tests/preferred-send-hour.test.ts
+++ b/tests/preferred-send-hour.test.ts
@@ -58,7 +58,13 @@ function createFakeSubscriberRef({
 }
 
 function fakeFieldValue() {
-  return { serverTimestamp: () => 'SERVER_TIMESTAMP' };
+  return { serverTimestamp: () => 'SERVER_TIMESTAMP', increment: (n: number) => ({ __increment: n }) };
+}
+
+function firestoreEventAt(daysAgo: number, hourUtc: number) {
+  const d = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+  d.setUTCHours(hourUtc, 0, 0, 0);
+  return { event_type: 'open', occurred_at: d.toISOString() };
 }
 
 describe('preferredSendHour (functions/src/lib)', () => {
@@ -345,6 +351,64 @@ describe('refreshPreferredSendHour — staleness gate (#3798 code review)', () =
     const result = await refreshPreferredSendHour(ref as never, fakeFieldValue());
     expect(wasEventsQueried()).toBe(true);
     expect(result.updated).toBe(true);
+  });
+});
+
+describe('refreshPreferredSendHour — churn instrumentation (#3798 Fix MEDIO-BASSO #6)', () => {
+  it('increments preferred_send_hour_churn_count when the newly computed hour differs from the stored one', async () => {
+    const staleDate = new Date(Date.now() - (PREFERRED_SEND_REFRESH_INTERVAL_MS + 60 * 60 * 1000));
+    const { ref, sets } = createFakeSubscriberRef({
+      docData: {
+        preferred_send_sample_count: 5,
+        preferred_send_hour_utc: 9,
+        preferred_send_strength: 0.8,
+        preferred_send_updated_at: staleDate,
+      },
+      events: [firestoreEventAt(1, 14), firestoreEventAt(2, 14), firestoreEventAt(3, 14)],
+    });
+
+    const result = await refreshPreferredSendHour(ref as never, fakeFieldValue());
+
+    expect(result.hourUtc).toBe(14);
+    expect(result.churned).toBe(true);
+    expect(sets[0].data.preferred_send_hour_churn_count).toEqual({ __increment: 1 });
+  });
+
+  it('does not increment when the newly computed hour matches the stored one', async () => {
+    const staleDate = new Date(Date.now() - (PREFERRED_SEND_REFRESH_INTERVAL_MS + 60 * 60 * 1000));
+    const { ref, sets } = createFakeSubscriberRef({
+      docData: {
+        preferred_send_sample_count: 5,
+        preferred_send_hour_utc: 14,
+        preferred_send_strength: 0.8,
+        preferred_send_updated_at: staleDate,
+      },
+      events: [firestoreEventAt(1, 14), firestoreEventAt(2, 14), firestoreEventAt(3, 14)],
+    });
+
+    const result = await refreshPreferredSendHour(ref as never, fakeFieldValue());
+
+    expect(result.hourUtc).toBe(14);
+    expect(result.churned).toBe(false);
+    expect(sets[0].data.preferred_send_hour_churn_count).toBeUndefined();
+  });
+
+  it('does not count the first assignment (null → hour) as churn', async () => {
+    const { ref, sets } = createFakeSubscriberRef({
+      docData: {
+        preferred_send_sample_count: 2,
+        preferred_send_hour_utc: null,
+        preferred_send_strength: null,
+        preferred_send_updated_at: new Date(),
+      },
+      events: [firestoreEventAt(1, 14), firestoreEventAt(2, 14), firestoreEventAt(3, 14)],
+    });
+
+    const result = await refreshPreferredSendHour(ref as never, fakeFieldValue());
+
+    expect(result.hourUtc).toBe(14);
+    expect(result.churned).toBe(false);
+    expect(sets[0].data.preferred_send_hour_churn_count).toBeUndefined();
   });
 });
 

--- a/tests/report-send-hour-impact.test.ts
+++ b/tests/report-send-hour-impact.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeEmail,
   parseDaysArg,
   parseSinceArg,
+  computeQueryFloor,
   argValue,
   GROUP_ORDER,
   IMMEDIATE_LABEL,
@@ -23,9 +24,10 @@ import {
 // with those two members is a faithful stand-in for a Firestore
 // QueryDocumentSnapshot here. No Firestore mocking needed.
 
-function deliveryDoc({ campaignId, email, sentAt, sendTimeSource = null, opened = false, clicked = false, messageId = null, canonicalId = true }: {
+function deliveryDoc({ campaignId, email, sentAt, sendTimeSource = null, opened = false, clicked = false, messageId = null, canonicalId = true, isOperatorVerification = false }: {
   campaignId: string; email: string; sentAt: Date; sendTimeSource?: string | null;
   opened?: boolean; clicked?: boolean; messageId?: string | null; canonicalId?: boolean;
+  isOperatorVerification?: boolean;
 }) {
   const id = canonicalId
     ? buildCanonicalDeliveryDocId(campaignId, email)
@@ -40,20 +42,29 @@ function deliveryDoc({ campaignId, email, sentAt, sendTimeSource = null, opened 
       message_id: messageId,
       opened_at: opened ? sentAt : null,
       clicked_at: clicked ? sentAt : null,
+      is_operator_verification: isOperatorVerification,
     }),
   };
 }
 
-function eventDoc({ campaignId, email, type, messageId = null }: {
-  campaignId?: string; email: string; type: 'open' | 'click'; messageId?: string | null;
+// `timestamp` defaults far in the future so tests that don't care about the
+// chronological guard (#3798) — most of them — don't need to specify one
+// explicitly and still credit against whatever `sentAt` the delivery doc uses.
+const FAR_FUTURE = new Date('2099-01-01T00:00:00.000Z');
+
+function eventDoc({ campaignId, alertId, email, type, messageId = null, timestamp = FAR_FUTURE }: {
+  campaignId?: string; alertId?: string; email: string; type: 'open' | 'click';
+  messageId?: string | null; timestamp?: Date;
 }) {
   return {
     id: `evt-${Math.random()}`,
     data: () => ({
       email: normalizeEmail(email),
       campaign_id: campaignId ?? null,
+      alert_id: alertId ?? null,
       event_type: type,
       message_id: messageId,
+      timestamp,
     }),
   };
 }
@@ -168,13 +179,23 @@ describe('aggregate — transactional sends excluded from the immediate/pre-feat
 });
 
 describe('aggregate — events filtering (job-alert cross-collection leakage)', () => {
-  it('ignores events with no campaign_id (job_alert_subscribers events use alert_id, not campaign_id)', () => {
+  it('ignores events with no campaign_id AND no alert_id (no send-side identifier to match against)', () => {
     const deliveries = [
       deliveryDoc({ campaignId: CAMPAIGN, email: 'a@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'personal' }),
     ];
-    const jobAlertEvent = { id: 'evt-1', data: () => ({ email: 'a@x.com', event_type: 'open' /* no campaign_id */ }) };
-    const { segments } = aggregate(deliveries, [jobAlertEvent], null);
+    const noIdEvent = { id: 'evt-1', data: () => ({ email: 'a@x.com', event_type: 'open' /* no campaign_id, no alert_id */ }) };
+    const { segments } = aggregate(deliveries, [noIdEvent], null);
     expect(segments.combined.personal.opens).toBe(0);
+  });
+
+  it('credits job-alert events via alert_id fallback (#3798 ALTO #3 — job alerts now write campaign_deliveries keyed the same way)', () => {
+    const ALERT_ID = 'alert-123';
+    const deliveries = [
+      deliveryDoc({ campaignId: ALERT_ID, email: 'a@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'personal' }),
+    ];
+    const jobAlertOpen = eventDoc({ alertId: ALERT_ID, email: 'a@x.com', type: 'open' });
+    const { segments } = aggregate(deliveries, [jobAlertOpen], null);
+    expect(segments.combined.personal.opens).toBe(1);
   });
 
   it('ignores non open/click event types (delivered/bounce/etc.)', () => {
@@ -184,6 +205,95 @@ describe('aggregate — events filtering (job-alert cross-collection leakage)', 
     const bounceEvent = eventDoc({ campaignId: CAMPAIGN, email: 'a@x.com', type: 'bounce' as unknown as 'open' });
     const { segments } = aggregate(deliveries, [bounceEvent], null);
     expect(segments.combined.personal.opens).toBe(0);
+  });
+});
+
+describe('aggregate — operator-verification exclusion (#3798 ALTO #2)', () => {
+  it('drops is_operator_verification deliveries and reports the count instead of counting them', () => {
+    const deliveries = [
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'op@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), isOperatorVerification: true }),
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'real@x.com', sentAt: new Date('2026-07-05T10:00:00Z'), sendTimeSource: 'personal' }),
+    ];
+    const { segments, droppedOperatorVerification } = aggregate(deliveries, [], null);
+    expect(droppedOperatorVerification).toBe(1);
+    expect(segments.combined[IMMEDIATE_LABEL].deliveries).toBe(0);
+    expect(segments.combined.personal.deliveries).toBe(1);
+  });
+});
+
+describe('aggregate — chronological guard (#3798 edge case: event before sent_at)', () => {
+  const SENT_AT = new Date('2026-07-16T10:08:21.275Z');
+
+  it('does not credit an open/click whose timestamp precedes this delivery\'s sent_at', () => {
+    const deliveries = [
+      deliveryDoc({ campaignId: 'unknown', email: 'a@x.com', sentAt: SENT_AT, sendTimeSource: 'personal' }),
+    ];
+    // Simulates the real root cause: an earlier send to the same untagged
+    // ('unknown') address left behind an open event, then a later untagged
+    // send overwrote sent_at on the shared canonical doc — orphaning it.
+    const staleOpen = eventDoc({ campaignId: 'unknown', email: 'a@x.com', type: 'open', timestamp: new Date(SENT_AT.getTime() - 1000) });
+    const { segments } = aggregate(deliveries, [staleOpen], null);
+    expect(segments.combined.personal.opens).toBe(0);
+  });
+
+  it('still credits an open/click whose timestamp is at or after sent_at', () => {
+    const deliveries = [
+      deliveryDoc({ campaignId: CAMPAIGN, email: 'a@x.com', sentAt: SENT_AT, sendTimeSource: 'personal' }),
+    ];
+    const freshOpen = eventDoc({ campaignId: CAMPAIGN, email: 'a@x.com', type: 'open', timestamp: new Date(SENT_AT.getTime() + 1000) });
+    const { segments } = aggregate(deliveries, [freshOpen], null);
+    expect(segments.combined.personal.opens).toBe(1);
+  });
+
+  it('does not credit the delivery doc\'s own opened_at/clicked_at when they precede sent_at (stale merge)', () => {
+    const doc = {
+      id: buildCanonicalDeliveryDocId('unknown', 'stale@x.com'),
+      data: () => ({
+        email: 'stale@x.com',
+        campaign_id: 'unknown',
+        sent_at: SENT_AT,
+        send_time_source: 'personal',
+        opened_at: new Date(SENT_AT.getTime() - 60_000), // stale — from a prior send, never cleared
+      }),
+    };
+    const { segments } = aggregate([doc], [], null);
+    expect(segments.combined.personal.opens).toBe(0);
+  });
+});
+
+describe('computeQueryFloor — "before" baseline anchoring (#3798 ALTO #1)', () => {
+  const SINCE = new Date('2026-07-12T00:00:00.000Z');
+  const DAYS = 20;
+
+  it('with no --since, floors at now - days (unchanged rolling-window behavior)', () => {
+    const now = new Date('2026-07-28T00:00:00.000Z');
+    const floor = computeQueryFloor(now, DAYS, null);
+    expect(floor.toISOString()).toBe(new Date(now.getTime() - DAYS * 86_400_000).toISOString());
+  });
+
+  it('regression: once now - days drifts past --since, the floor stays anchored before --since instead of AT it (the Aug-1 vanishing-baseline bug)', () => {
+    // now - 20d == SINCE exactly: the day the old `sinceDate < cutoffDate ?
+    // sinceDate : cutoffDate` ternary first floors the query AT sinceDate,
+    // permanently emptying the "before" segment from this point forward.
+    const now = new Date('2026-08-01T00:00:00.000Z');
+    const floor = computeQueryFloor(now, DAYS, SINCE);
+    expect(floor.getTime()).toBeLessThan(SINCE.getTime());
+    expect(floor.toISOString()).toBe(new Date(SINCE.getTime() - DAYS * 86_400_000).toISOString());
+  });
+
+  it('keeps anchoring to (since - days) indefinitely as now advances further', () => {
+    const now = new Date('2026-09-15T00:00:00.000Z'); // weeks past the drift-over point
+    const floor = computeQueryFloor(now, DAYS, SINCE);
+    expect(floor.toISOString()).toBe(new Date(SINCE.getTime() - DAYS * 86_400_000).toISOString());
+  });
+
+  it('anchors to (since - days) even before the drift-over point, whenever that is the wider (earlier) floor', () => {
+    // now - 20d (2026-06-25) is well before SINCE (07-12), but (since - days)
+    // (06-22) is wider still — always take the earlier floor so the baseline
+    // window is stable from day one, not just once drift sets in.
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const floor = computeQueryFloor(now, DAYS, SINCE);
+    expect(floor.toISOString()).toBe(new Date(SINCE.getTime() - DAYS * 86_400_000).toISOString());
   });
 });
 
@@ -215,28 +325,42 @@ describe('aggregate — since-date boundary (before/after split)', () => {
   });
 });
 
-describe('n<100 small-sample flagging (SMALL_SAMPLE_THRESHOLD)', () => {
-  it('formatSegmentTable annotates a group with fewer than 100 deliveries as not significant', () => {
+describe('significance testing — real two-proportion z-test, not a fixed n<100 threshold (#3798 Fix MEDIO #4)', () => {
+  it('formatSegmentTable prints raw counts with no per-row significance claim', () => {
+    // A single group has no "significant/not significant" verdict in isolation
+    // — that requires a comparison. The old n<100 annotation made a claim the
+    // data couldn't support; the table now just reports numbers.
     const cells = newSegment();
     cells.personal = { deliveries: 42, opens: 10, clicks: 2 };
     const table = formatSegmentTable('title', cells);
-    expect(table).toContain('n<100, not significant');
+    expect(table).not.toContain('significant');
   });
 
-  it('does NOT flag a group with >= 100 deliveries', () => {
-    const cells = newSegment();
-    cells.personal = { deliveries: 150, opens: 30, clicks: 5 };
-    const table = formatSegmentTable('title', cells);
-    const personalLine = table.split('\n').find((l) => l.trim().startsWith('personal'));
-    expect(personalLine).toBeDefined();
-    expect(personalLine).not.toContain('not significant');
+  it('comparisonLine flags two LARGE (n=500) groups with near-identical rates as not significant', () => {
+    // Both groups clear the old n>=100 threshold, so the old heuristic would
+    // never have flagged this — but a 50.0% vs 49.6% gap on n=500 is
+    // genuinely indistinguishable from noise. Real test: p ~ 0.9.
+    const a = { deliveries: 500, opens: 250, clicks: 50 };
+    const b = { deliveries: 500, opens: 248, clicks: 50 };
+    const line = comparisonLine('x', a, b, 'a', 'b');
+    expect(line).toContain('not significant');
   });
 
-  it('comparisonLine flags [not significant] when either side is below the threshold', () => {
-    const small = { deliveries: 10, opens: 5, clicks: 1 };
-    const big = { deliveries: 500, opens: 250, clicks: 50 };
-    expect(comparisonLine('x', small, big, 'a', 'b')).toContain('not significant');
-    expect(comparisonLine('x', big, big, 'a', 'b')).not.toContain('not significant');
+  it('comparisonLine flags two SMALL (n=60) groups with a decisive rate gap as significant', () => {
+    // Both groups are below the old n<100 threshold, so the old heuristic
+    // would always have flagged this as "not significant" — but an 83% vs 8%
+    // gap on n=60 is an enormous, real effect (z ~ 8). Real test: p << 0.05.
+    const a = { deliveries: 60, opens: 50, clicks: 10 };
+    const b = { deliveries: 60, opens: 5, clicks: 1 };
+    const line = comparisonLine('x', a, b, 'a', 'b');
+    expect(line).toContain('[significant');
+    expect(line).not.toContain('not significant');
+  });
+
+  it('comparisonLine reports the p-value inline', () => {
+    const a = { deliveries: 500, opens: 250, clicks: 50 };
+    const b = { deliveries: 500, opens: 248, clicks: 50 };
+    expect(comparisonLine('x', a, b, 'a', 'b')).toMatch(/p=\d\.\d{3}/);
   });
 });
 


### PR DESCRIPTION
## Implementato

Data-quality and edge-case fixes for the send-time personalization pipeline (#3798), covering the open/click-before-send edge case, all high/medium/low findings from the audit, and 8 additional sibling-pattern fixes surfaced across three rounds of `check-sibling-patterns.mjs` sweeps on this changeset (each fix commit widened the shared-token surface, so the hook re-triggered after each commit).

**Core fixes:**
1. **`report-send-hour-impact.mjs` — disappearing baseline (ALTO #1).** The "before" cohort was a rolling window that emptied out over time instead of staying anchored to a fixed pre-feature split date. Anchored the before/after split to the feature-activation date (`--since`, default `2026-07-12`) so the baseline stays comparable indefinitely.
2. **`report-send-hour-impact.mjs` — operator test-send contamination (ALTO #2).** `aggregate()` now excludes `campaign_deliveries` docs where `is_operator_verification` is true, so manual QA sends (`send-newsletter.mjs --test`) no longer dilute the `immediate` bucket.
3. **`send-job-alerts.mjs` — job alerts invisible to the report (ALTO #3).** Job-alert sends never wrote a `campaign_deliveries` doc, so they had no `send_time_source`/`sent_at` for the report to key on. Added the same delivery-doc write path job-alert sends use for open/click tracking.
4. **`report-send-hour-impact.mjs` — fake significance (MEDIO #4).** Replaced the fixed `n<100` "significant/not" label with a real two-proportion z-test (`p=...`), so small-but-real effects aren't dismissed and large-but-noisy ones aren't rubber-stamped.
5. **`preferredSendHour.js` — churn instrumentation (MEDIO-BASSO #6).** Added logging/counters around preferred-hour churn to gather the data needed to calibrate the 6h staleness gate later (no gate change in this PR — insufficient data yet, tracked as a follow-up decision, not deferred scope).
6. **Edge case: `occurred_at < sent_at`.** Studied the webhook-retry/clock-skew scenario where an open/click event's timestamp precedes the delivery's `sent_at` (e.g., a provider retries a stale webhook after a resend, or a send lacking a real campaign id collides with an earlier send on the shared `'unknown'`-keyed doc). Added a guard so such events don't get attributed to the wrong delivery / produce negative latency in the report.

**Sibling-pattern sweep — round 1** (same constructs as #1/#2/#4 above, found in files the initial pass missed):
7. **`scripts/lib/newsletter-ab-data.mjs`** — `loadCampaignVariantTotals`/`loadCampaignSegmentReport` counted operator QA sends as real subscriber traffic (same bug as #2, different call site — this loader feeds both the A/B report and the send pipeline's auto-promotion resolver). Added the same `is_operator_verification` exclusion.
8. **`scripts/send-newsletter.mjs`** — the PostHog A/B `email_sent` exposure event fired for operator test sends too, polluting the `email_sent → email_opened` funnel with sends nobody receives as a subscriber. Guarded the capture call behind `!meta.isOperatorVerification`.
9. **`.github/workflows/send-hour-impact-report.yml`** — the auto-posted comment on #3798 still described the old fixed `n<100` cutoff (stale text left over from before fix #4). Updated to describe the actual two-proportion z-test output.

**Sibling-pattern sweep — round 2** (class 2 — operator-verification exclusion missing from the OPENED-event PostHog capture in the ESP webhook cores, not just the Firestore aggregation loops fixed in #2/#7):
10. **`functions/src/lib/emailExperimentPostHog.js`** — `lookupSentVariant` extended to also return `isOperatorVerification`, read off the same already-fetched delivery-doc snapshot (no extra Firestore read).
11. **`functions/src/newsletterResendWebhookCore.js`** — `captureEmailEvent(OPENED, ...)` now skipped when the delivery is an operator-verification test send.
12. **`functions/src/newsletterMailjetWebhookCore.js`** — same guard.
13. **`functions/src/newsletterMailgunWebhookCore.js`** — same guard.
14. **`functions/src/newsletterMailerooWebhookCore.js`** — same guard.

**Sibling-pattern sweep — round 3** (class 4 — non-unique campaignId fallback):
15. **`services/newsletterSubscribers.ts`** — `recordNewsletterClick` and `applyNewsletterDeliveryEvent` both passed `campaignId: input.campaignId || 'unknown'` into `upsertNewsletterDelivery`, neutralizing that function's own `!campaignId` guard and causing unrelated newsletter click/event docs to collide on the shared `unknown__<email>` Firestore doc (same collision class already fixed on the send-path doc ids elsewhere in this PR). Removed the fallback — the attribution write is now skipped entirely when there's no real campaignId, instead of corrupting a shared doc.

**Verification:**
- `npx vitest run` on all touched/related test files: 293 passed, 0 failed across 16 files (preferred-send-hour, report-send-hour-impact, job-alert-email, newsletter-ab-promotion, all 5 webhook-core test files, email-experiment-posthog, newsletter-subscribers sector-interest/resubscribe, newsletter-subscriber-status, newsletter-confirmation, newsletter-engagement-ratelimit).
- Full repo `npx vitest run` post-rebase: 137907 passed, 0 relevant failures across 1341 test files. The 2 timeouts seen under full-suite load (`search-console-compat.test.ts`, `ti-sector-hub-canton-scope.test.ts`) are unrelated to this PR (SEO 404-compat / sector-hub canton scope) and pass cleanly in isolation — pre-existing resource-contention flakiness, not a regression.
- GitNexus `detect_changes` (scope=compare vs origin/main): risk_level `low`, `affected_count: 0` across the full diff.
- PII scan against the full diff: clean.
- `node --check` on all modified `.js` files: clean.

## Non implementato (ancora)

Nessuno per lo scope di questa PR.

Il sibling-pattern sweep si è ripetuto 3 volte — ogni commit di fix ha introdotto nuovi costrutti condivisi (nuovi nomi di funzione/campo), ritriggerando l'hook al push successivo. Ogni round è stato valutato individualmente per Non-Negotiable #6, non con un dismiss collettivo:

**Round 1 (36 candidati grezzi, dopo il commit dei core-fix #1-6):**
- 3 candidati reali → fixati in questa PR (punti 7-9 sopra).
- 28 candidati → falsi positivi (condividono token/identificatori con il diff ma costrutto semanticamente diverso — es. altri usi di `campaign_id`/`sent_at`/`variant` non legati a nessuna delle 5 classi di antipattern).
- 2 candidati reali → root cause diversa dal pattern di questa PR, tracciati separatamente:
  - Collisione `campaignId` fallback `'unknown'` nei webhook core Resend + Mailjet (nessun buffer message-id prima del fallback) → issue esistente **#4847**, aggiornata con la conferma Mailjet + vittima live (`scripts/newsletter-winback-campaign.mjs`).
  - Il bucket `immediate` di `report-send-hour-impact.mjs` include anche i send transazionali calculator/LAMal (`sendCalculatorReport.js`), che hanno `campaign_id` reale ma nessun `send_time_source` → issue **#4853**, già fixata e mergiata su main indipendentemente da questa PR (PR #4856, block-list `TRANSACTIONAL_CAMPAIGN_IDS`). Il rebase su main ha unito quel fix con l'esclusione `droppedOperatorVerification` di questa PR nello stesso `aggregate()` — entrambi i contatori convivono (vedi `droppedTransactional` + `droppedOperatorVerification` in `report-send-hour-impact.mjs`).

**Round 2 (35 candidati grezzi, dopo il commit del round 1):**
- 4 candidati reali → fixati in questa PR (punti 11-14 sopra: Resend/Mailjet/Mailgun/Maileroo).
- 1 candidato stessa-forma-ma-inerte → documentato, non fixato: **`functions/src/newsletterMailtrapWebhookCore.js`** ha lo stesso gap (manca l'esclusione `is_operator_verification` prima di `captureEmailEvent(OPENED, ...)`), ma `'mailtrap'` è già in `EXPERIMENT_EXCLUDED_PROVIDERS` (`emailExperimentPostHog.js`), quindi `captureEmailEvent` è già un no-op incondizionato per quel provider indipendentemente dallo stato operator-verification — nessuna differenza di comportamento runtime, lasciato invariato.
- 30 candidati → falsi positivi (stesso principio del round 1: token/identificatore condiviso — `getFirestoreAdmin`, `collectionGroup`, `persistDelivery`, ecc. — ma dominio o costrutto diverso dai 5 antipattern).

**Round 3 (31 candidati grezzi, dopo il commit del round 2) — valutazione dettagliata per-file:**
- 1 candidato reale → fixato in questa PR (punto 15 sopra: `services/newsletterSubscribers.ts`).
- 1 candidato reale → root cause diversa (canale mai strumentato dall'inizio, non regressione di questa PR), tracciato separatamente: **`scripts/send-saved-jobs-digest.mjs`** — `sendDigest()` chiama `sendEmailCascade(...)` senza alcun callback `onSent`, e nessun delivery/campaign doc viene mai scritto per questo canale, quindi le sue aperture/click non sono mai attribuibili. Instrumentarlo è un'estensione di feature a un canale mai tracciato, non un fix chirurgico dello stesso antipattern del diff → nuova issue **#4862**.
- 2 candidati già noti/valutati nei round precedenti, non ricontati: `functions/src/lib/deliveryDocId.js` (falso positivo — puro formatter di stringa, condivide solo il nome `buildDeliveryDocId`), `functions/src/newsletterMailtrapWebhookCore.js` (già documentato sopra come same-shape-inerte).
- 27 nuovi candidati → falsi positivi, valutati individualmente:
  - `scripts/newsletter-ab-report.mjs` — consuma solo i loader già corretti; il testo `n<100` è un caveat informativo dopo che il vero z-test ha già deciso la significatività, non la gate lui stesso.
  - `services/newsletter-ab-stats.mjs` — è il riferimento del fix: `twoProportionTest` + `pickWinner` combinano correttamente soglia-dati e test statistico vero.
  - `functions/src/lib/engagementScore.js` — `openRate`/`clickRate` qui sono rapporti lifetime per-subscriber da contatori già salvati, non un confronto A/B da proteggere da operator-verification.
  - `scripts/lib/send-schedule.mjs` — soglie di sufficienza-dati (`PREFERRED_SEND_MIN_EVENTS`), mai presentate come "significatività"; nessun confronto di proporzioni nel file.
  - `functions/src/emailCascade.js` — `persistDelivery` compare solo in un commento; il modulo delega sempre ai chiamanti (già fixati) per la scrittura del doc di delivery.
  - `scripts/lib/subscriberFromFirestoreRow.mjs` — puro projector di riga Firestore, nessuna scrittura, nessun campaignId, nessuna logica operator-verification.
  - `scripts/setup-posthog-email-funnel.mjs` — script one-off che crea/cerca definizioni di Funnel Insight in PostHog; nessuna cattura evento propria, la capture sottostante è già corretta.
  - `services/dormantWinbackStage1Email.mjs` — puro template builder HTML/testo, nessun accesso Firestore o logica di invio/persistenza.
  - `services/newsletter-seasonal.mjs` — puro selettore di contenuto stagionale deterministico, nessun Firestore, nessuna logica di invio.
  - `scripts/backfill-newsletter-job-context.mjs` — `usedFallback` è un fallback di arricchimento contenuti one-shot, non legato a query-floor/aggregazione eventi.
  - `scripts/migrate-job-alerts-to-subscribers.mjs` — migrazione strutturale one-off, `collectionGroup` compare solo nei commenti.
  - `build-plugins/relatedSearchClustersPlugin.ts` — `droppedNonCanonical` conta URL di sitemap scartati per `<link rel=canonical>`, dominio SSG/sitemap non email.
  - `components/comparators/CurrencyExchangeStats.tsx` — `sampleCount` conta osservazioni storiche di cambio EUR/CHF in un grafico, nessun confronto varianti A/B.
  - `scripts/backfill-jobalert-legacy-daily-override.mjs` — query `collectionGroup('alerts')` per pinnare config legacy, non tocca mai `campaign_deliveries`/`events`.
  - `scripts/backfill-jobalerts-from-newsletter.mjs` — backfill di campi di config alert da segnali newsletter, nessuna aggregazione eventi/campaignId.
  - `scripts/backfill-newsletter-campaign-ids.mjs` — script di *riparazione* proprio per i postumi storici del bug `campaign_id === 'unknown'`; aggiorna solo il campo `campaign_id` su doc già esistenti (per `doc.ref`), non costruisce mai un nuovo doc id con fallback — non perpetua il bug.
  - `scripts/backfill-personalization-sector.mjs` — ri-derivazione di `sector_interest`/`job_category`, nessun coinvolgimento di eventi/campagne.
  - `scripts/check-subscriber-history.mjs` — tool diagnostico read-only per una singola email; non è un report aggregato, quindi non c'è nulla da contaminare.
  - `scripts/dmarc-monitor.mjs` — `sinceDate` alimenta una query DMARC rolling "ultimi N giorni" senza alcun concetto di baseline fissa da cui driftare.
  - `scripts/lib/events-utils.mjs` — `cutoffDate` è una finestra di grazia intenzionalmente rolling per eventi Ticino locali scaduti, dominio non-email.
  - `scripts/lib/job-localization-pipeline.mjs` — il match è un artefatto di re-indentazione del diff; la chiave di cache qui è un hash indipendente da `provider`, nessun rischio di collisione analogo.
  - `scripts/lib/resolve-fb-posted-jobs-conflict.mjs` — `scheduledFor` è un campo del ledger di scheduling post Facebook, dominio non-email.
  - `scripts/report-job-alert-engagement-tiers.mjs` — query `collectionGroup('alerts')` per config/tier cadenza, conteggi semplici non un test di significatività, non legge mai `campaign_deliveries`/`events`.
  - `scripts/schedule-fb-jobs-daily.mjs` — stesso ledger/dominio Facebook del file precedente.
  - `services/jobAlertService.ts` — query client-side per il cap di 3-alert-per-utente sui config di ricerca, non su `campaign_deliveries`/`events`.

Tutti i candidati reali non fixati qui restano root-cause diverse dai 5 antipattern di questa PR (non "operator-verification exclusion" / "significance test" / "baseline anchor" / "campaignId univoco" nello stesso costrutto) — per questo restano fuori da questa PR invece di bloccarla, coerente con Non-Negotiable #8 (elencati con stato/next-step tracciato, non deferiti a bullet vuoto).

**Round 4** (dopo il rebase su origin/main, che nel frattempo aveva mergiato indipendentemente il fix upstream #4853/#4856 nello stesso `aggregate()`): 30 candidati grezzi — 28 già valutati nei round precedenti (incl. `functions/src/lib/deliveryDocId.js` e `functions/src/newsletterMailtrapWebhookCore.js`, e `scripts/newsletter-winback-campaign.mjs` già citato nel punto #4847 sopra), 1 nuovo candidato:
- `functions/src/sendCalculatorReport.js` — costrutto condiviso segnalato: `await subscriberRef.set({` (rimosso dal diff in `preferredSendHour.js`, che ora usa una variabile intermedia `update` per poter condizionalmente aggiungere `preferred_send_hour_churn_count`). Falso positivo: è lo stesso idioma Firestore generico (`ref.set({...}, {merge:true})`), non lo stesso antipattern — qui è un upsert di subscriber pending/status per il tool calculator/LAMal, nessuna relazione con churn del preferred-hour, baseline, significatività, o campaignId. Lo stesso file era già oggetto del fix upstream #4853/#4856 (merge indipendente), non correlato a questo match.

**Round 5** (dopo un secondo rebase su origin/main per risolvere un conflitto di merge — vedi sotto): 30 candidati grezzi, tutti e 30 già individualmente valutati nei round 1-4 sopra (stesso identico diff finale, solo base spostata più avanti — nessun candidato nuovo). Nessuna rivalutazione necessaria.

**Conflitto di rebase (secondo rebase, origin/main avanzato di 580 commit dalla PR-open):**
- `functions/src/newsletterResendWebhookCore.js` — conflitto sulle righe di import: un lato aggiungeva `lookupSentVariant` (punto 11), l'altro `uniqueUnknownFallback` (punto 15). Merge d'unione, entrambi gli import mantenuti — nessuna perdita di logica.
- `services/newsletterSubscribers.ts` — conflitto su 2 righe `campaignId: input.campaignId || uniqueUnknownFallback(...)`: risolto mantenendo l'intento del fix del punto 15 (rimozione fallback, plain `input.campaignId`). Rimossa anche la funzione `uniqueUnknownFallback` ora morta (0 usi residui, verificato via grep) insieme al commento esplicativo che la introduceva.

Relates to #3798.
