### PR TITLE
fix(ci): sparse-checkout solo dove il partial clone è già attivo (regressione #4871)

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -177,37 +177,23 @@ jobs:
           # → niente stallo. Se mai servisse la history per un caso futuro,
           # ripristinare depth:0.
           fetch-depth: 1
-          # Sparse: `fetch-depth: 1` da solo scaricava comunque OGNI blob
-          # dell'albero HEAD — misurato 87s di Checkout (75s di sola `Fetching
-          # the repository`) sul job review di run 30353920865, cioè ~1/4 di un
-          # job da 371s. L'albero pesa ~2.6GB e le voci grosse sono binari o
-          # dump dati che il reviewer non apre MAI: public/images/events
-          # (790MB), public/images/blog (361MB), data/jobs (627MB, slice
-          # crawler), data/translation-cache (182MB), data/seo-404-compat
-          # (164MB), docs/newsletter-qa (90MB) → ~2.1GB tagliati.
+          # NIENTE `sparse-checkout`, ed è una scelta MISURATA. Sarebbe stato
+          # allettante: l'albero pesa ~2.6GB e il reviewer non apre mai
+          # public/images/events (790MB), public/images/blog (361MB),
+          # data/jobs (627MB), data/translation-cache (182MB),
+          # data/seo-404-compat (164MB) né docs/newsletter-qa (90MB).
           #
-          # Perché è safe per il reviewer: il diff arriva da `gh pr diff`
-          # (GitHub API, non dal working tree) e il probing cross-file di
-          # REVIEW.md step 5 è scopato al CODE. `public/images/brands` (1.2MB)
-          # resta incluso perché è l'unica sottodir di images letta da codice.
+          # Ma impostarlo porta actions/checkout su `--filter=blob:none`, e su
+          # questo repo convertire il fetch bulk in lazy-fetch on-demand COSTA
+          # invece di risparmiare: provato su tests.yml (fetch bulk identico a
+          # questo, run 30361290650) il Checkout è passato da 75s a 169s, +125%.
+          # Lo sparse-checkout paga solo dove il partial clone è già in uso —
+          # in pr-body-contract.yml, che ha `filter: blob:none`, ha portato il
+          # Checkout da ~200s a 77s. Qui il fetch è bulk, quindi no.
           #
-          # Nota sul rischio noto: `sparse-checkout` fa passare actions/checkout
-          # a `--filter=blob:none` (partial clone) — lo stesso meccanismo che in
-          # passato ha stallato un Checkout per 11 MINUTI (run 27672265799, PR
-          # #2394) mangiando il budget della review. Qui il lazy-fetch non ha
-          # motivo di scattare, perché gli esclusi sono binari/dump che nessun
-          # `Read`/`rg` del reviewer tocca; se mai scattasse, `timeout-minutes`
-          # sotto trasforma uno stallo in un fallimento VISIBILE (job rosso)
-          # invece che in una review idle senza diagnosi.
-          sparse-checkout: |
-            /*
-            !/public/images/events
-            !/public/images/blog
-            !/data/jobs
-            !/data/translation-cache
-            !/data/seo-404-compat
-            !/docs/newsletter-qa
-          sparse-checkout-cone-mode: false
+          # (Il rischio non è solo di lentezza: è il partial clone ad aver
+          # stallato un Checkout per 11 MINUTI su questo stesso job — run
+          # 27672265799, PR #2394 — lasciando la review idle senza diagnosi.)
         timeout-minutes: 8
 
       # Headroom install (~63s misurati su run 30353920865) in BACKGROUND: è

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,27 +66,19 @@ jobs:
     # measured run.)
     timeout-minutes: 20
     steps:
+      # NIENTE `sparse-checkout` qui, ed è una scelta MISURATA, non un'omissione.
+      # Questo checkout è un fetch bulk shallow (`fetch-depth: 1` implicito, no
+      # `filter:`) e costa 75s (run 30355205859). Impostare `sparse-checkout`
+      # porterebbe actions/checkout su `--filter=blob:none`, convertendo quel
+      # singolo trasferimento in migliaia di lazy-fetch on-demand: provato su
+      # questa stessa PR (run 30361290650) il Checkout è salito a 169s, +125%,
+      # mangiandosi il guadagno dello split sotto.
+      #
+      # Regola generale ricavata dal confronto: lo sparse-checkout conviene solo
+      # dove il partial clone è GIÀ in uso — in pr-body-contract.yml, che ha
+      # `filter: blob:none`, escludere public/images/{events,blog} ha portato il
+      # Checkout da ~200s (280/141/177s su tre run) a 77s. Qui no.
       - uses: actions/checkout@v5
-        with:
-          # Sparse: il Checkout costava 75s misurati (run 30355205859) perché
-          # scaricava ogni blob dell'albero HEAD (~2.6GB). `public/images` da
-          # solo pesa 1153MB, di cui events 790MB + blog 361MB: immagini
-          # binarie che nessun test apre. Restano incluse `public/images/brands`
-          # (1.2MB) — fuel-station-redesign / job-alert-email / fuel-daily
-          # verificano la presenza-su-disco dei loghi brand — e TUTTO `data/`,
-          # che è l'input di assemble-jobs-dataset.mjs e dei test che ne
-          # leggono gli output.
-          #
-          # `sparse-checkout` porta actions/checkout su `--filter=blob:none`
-          # (partial clone). `timeout-minutes` sotto è la rete di sicurezza
-          # contro il lazy-fetch che in passato ha stallato un checkout per 11
-          # minuti su un altro workflow (run 27672265799).
-          sparse-checkout: |
-            /*
-            !/public/images/events
-            !/public/images/blog
-          sparse-checkout-cone-mode: false
-        timeout-minutes: 8
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
Correzione di una regressione entrata con #4871: lo sparse-checkout è vantaggioso solo dove il partial clone è già in uso, e su `tests` costa invece di risparmiare. #4871 è stata auto-mergiata (drift-fallback deterministico, perché tocca `pr-review-loop.yml`) mentre stavo misurando la sua prima run, quindi la correzione arriva come PR concatenata.

## Implementato

**Rimosso `sparse-checkout` da `tests.yml` — misurato come regressione**
- Run 30361290650 (PR #4871): Checkout **75s → 169s, +125%**, e job totale **648s → 686s**, cioè più lento della baseline nonostante lo split dell'assemble funzionasse.
- Causa: `tests` fa un fetch **bulk** (`fetch-depth: 1`, nessun `filter`). Impostare `sparse-checkout` porta actions/checkout su `--filter=blob:none`, e su questo repo convertire un trasferimento unico in migliaia di lazy-fetch on-demand costa più dei blob risparmiati.

**Rimosso `sparse-checkout` da `pr-review-loop.yml` — stessa categoria, non misurabile**
- Anche lì il fetch è bulk (`fetch-depth: 1`, no filter), quindi si applica la stessa dinamica.
- Non è collaudabile su una PR: `pr-review-loop` parte via `workflow_run` e usa sempre il file di `main`. Non lascio su un workflow non misurabile un costrutto che sull'unico caso misurabile ha peggiorato del 125% — tanto più che è proprio il partial clone ad aver stallato un Checkout per 11 minuti su questo job (run 27672265799, PR #2394), causa #1 storica di "review idle".

**Mantenuto `sparse-checkout` in `pr-body-contract.yml` — lì è un guadagno misurato**
- Quel job usa **già** `filter: blob:none` (serve `fetch-depth: 0` a `check-sibling-patterns.mjs` per diffare contro `BASE_REF`), quindi escludere `public/images/{events,blog}` riduce i blob da lazy-fetchare senza introdurre il partial clone.
- Checkout **~200s → 77s** (baseline 280s / 141s / 177s su tre run; run 30361290618 con sparse: 77s). Job intero da 149-296s a **90s**.

**Invariato tutto il resto di #4871** — misurato funzionante e non toccato qui:
- Split assemble/vitest: assemble 240s **interamente in background**, `wait-all` costato 10s. Tutti i check verdi, partizione 762+597=1359 rispettata in CI.
- Fix del proxy Headroom (`--no-ccr`), install in `background:`, guard di body-contract in `background:`.

## Non implementato (ancora)

Nessuno scope residuo.

**Effetto netto atteso su `tests`, da verificare post-merge**: baseline 648s, meno ~230s di assemble mascherato, più ~63s di costo del doppio startup vitest (230s + 228s contro 395s di run unica) → attesi ~580s. Se la prima run su `main` non scende sotto 648s, o risulta rossa, il trigger di revert dichiarato in #4871 resta valido e va applicato allo split (il resto è indipendente).

## Test plan

- [x] Cherry-pick pulito su `origin/main`; verificato `sparse-checkout:` = 0 occorrenze in `tests.yml` e `pr-review-loop.yml`, 1 in `pr-body-contract.yml`.
- [x] YAML dei tre workflow valido.
- [ ] Post-merge: Checkout di `tests` tornato a ~75s e job sotto 648s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
