### PR TITLE
fix(fast-publish): serialize per article, not per section

### DIFF
--- a/.github/workflows/fast-publish-article.yml
+++ b/.github/workflows/fast-publish-article.yml
@@ -37,21 +37,29 @@ on:
         required: false
         type: string
 
-# Serialize by SECTION, not globally: frontaliere and svizzera articles never
-# contend for the same shard repos, so they run fully in parallel. Two
-# articles in the SAME section dispatched close together (e.g. the stream-C
-# reconciler re-dispatching while a producer's own dispatch is still
-# in-flight, or two journalist articles published in the same 15-min cron
-# window) DO need to serialize: push-article-shard-incremental.sh's target
-# shard repos (frontaliere-articolifrontaliere-<loc> etc.) take a single SSH
-# deploy key each — two concurrent pushes to the same shard repo would race
-# each other's git push. `cancel-in-progress: false` is deliberate (mirrors
-# deploy.yml's pages-build-run group rationale): the shard push is
-# merge-only/additive, so a QUEUED second run must still complete and push
-# its own article rather than being cancelled and silently dropping that
-# article's fast-publish.
+# Serialize per ARTICLE, not per section.
+#
+# This group was originally `fast-publish-${{ inputs.section }}` with the stated
+# intent that "a QUEUED second run must still complete and push its own article
+# rather than being cancelled". A per-section group cannot deliver that: GitHub
+# holds exactly ONE pending run per concurrency group, so when a third run is
+# queued the pending one is CANCELLED. Any producer that dispatches several
+# articles at once therefore loses the middle ones silently:
+#   - publish-journalist-articles.yml dispatches one run per id in
+#     `published_ids`, and a single 15-min cron window can publish several;
+#   - scripts/reconcile-fast-publish-articles.mjs dispatches one run per article
+#     registered since the deploy's build SHA — by construction a backlog.
+# Both are exactly the paths that exist to guarantee completeness. This is the
+# same starvation that motivated the whole feature: deploy.yml's own
+# `pages-build-run` group dropped 12 consecutive queued runs on 2026-07-28.
+#
+# Concurrent runs for DIFFERENT articles are safe against the same shard repo:
+# push-article-shard-incremental.sh never force-pushes and builds its commit on
+# the remote tip, so a loser gets a non-fast-forward, re-clones onto the new tip
+# and rebuilds (exercised by its concurrent-writer test). Two runs for the SAME
+# article still serialize here, which is the only race worth preventing.
 concurrency:
-  group: fast-publish-${{ inputs.section }}
+  group: fast-publish-${{ inputs.section }}-${{ inputs.article_id }}
   cancel-in-progress: false
 
 permissions:

--- a/tests/fast-publish-workflow-invariants.test.ts
+++ b/tests/fast-publish-workflow-invariants.test.ts
@@ -1,0 +1,100 @@
+// Invariants of the fast-publish path (#4837) that are NOT observable from a
+// green CI run.
+//
+// Every defect pinned here was live at some point and shipped green: the
+// pipeline is deliberately fault-tolerant (per-locale `|| fail=1`,
+// `continue-on-error`, best-effort scripts that exit 0), so a broken fast path
+// degrades to "the article just goes live via the slow deploy instead" and
+// nothing turns red. These assertions are the only thing standing between a
+// well-meaning edit and a silently inert feature.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const read = (p: string) => readFileSync(resolve(p), 'utf8');
+
+describe('fast-publish workflow invariants', () => {
+  const workflow = read('.github/workflows/fast-publish-article.yml');
+
+  it('serializes per article, not per section', () => {
+    // A per-section group cannot keep batched dispatches: GitHub holds exactly
+    // ONE pending run per group, so a third queued run cancels the pending one.
+    // publish-journalist-articles.yml (one dispatch per published id) and
+    // reconcile-fast-publish-articles.mjs (one per backlogged article) would
+    // both silently lose their middle articles.
+    const group = /concurrency:\s*\n\s*group:\s*(.+)/.exec(workflow)?.[1] ?? '';
+    expect(group).toContain('inputs.article_id');
+  });
+
+  it('never installs dependencies on the critical path', () => {
+    // The whole point is skipping the full build; `npm ci` would add ~1-2 min
+    // to a path whose entire render takes under a second.
+    expect(workflow).not.toMatch(/^\s*run:\s*npm ci\b/m);
+  });
+
+  it('pings search engines only after live verification, never before', () => {
+    const notifyIdx = workflow.indexOf('Notify search engines');
+    const verifyIdx = workflow.indexOf('Verify shard URLs are live');
+    expect(verifyIdx).toBeGreaterThan(-1);
+    expect(notifyIdx).toBeGreaterThan(verifyIdx);
+    // and it must be gated on that step's outcome, not merely ordered after it
+    const notifyBlock = workflow.slice(notifyIdx, notifyIdx + 400);
+    expect(notifyBlock).toMatch(/steps\.verify\.outcome\s*==\s*'success'/);
+  });
+});
+
+describe('push-article-shard-incremental.sh invariants', () => {
+  const raw = read('scripts/lib/push-article-shard-incremental.sh');
+  // Strip comment lines: this file documents at length WHY it never
+  // force-pushes and what commit-tree needs, so matching the raw text finds the
+  // prose instead of the code.
+  const script = raw
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+
+  it('configures a git identity before commit-tree', () => {
+    // An Actions runner has no default identity, so `git commit-tree` dies with
+    // "Author identity unknown" — on every retry, for every locale, every run.
+    // Local runs hide this because developer machines have a global identity.
+    const identityIdx = Math.max(
+      script.indexOf('config user.email'),
+      script.indexOf('config user.name'),
+    );
+    const commitTreeIdx = script.indexOf('commit-tree');
+    expect(identityIdx).toBeGreaterThan(-1);
+    expect(commitTreeIdx).toBeGreaterThan(identityIdx);
+  });
+
+  it('uses write-tree --missing-ok so a partial clone stays partial', () => {
+    // Plain `write-tree` eagerly fetches a blob for EVERY index entry, which on
+    // an 86 MB shard means re-downloading the whole repo per article and
+    // defeats the --filter=blob:none clone.
+    expect(script).toMatch(/write-tree\s+--missing-ok/);
+  });
+
+  it('never force-pushes', () => {
+    // Merge-only by construction: the commit is built on the remote tip, so a
+    // loser must re-clone and rebuild rather than clobber a concurrent writer.
+    expect(script).not.toMatch(/push\s+(-f|--force)\b/);
+  });
+});
+
+describe('wait-for-live-article-shards.mjs invariants', () => {
+  const script = read('scripts/wait-for-live-article-shards.mjs');
+
+  it('sends a User-Agent on the content fetch', () => {
+    // undici's fetch sends none, and the zone firewall answers an empty UA with
+    // 403 plus a challenge page — measured: plain fetch -> 403/5730B, same URL
+    // with a UA -> 200/23505B. Without this the content check can never match
+    // and every publish burns its full timeout reporting failure.
+    expect(script).toContain('DEFAULT_LIVE_CHECK_USER_AGENT');
+  });
+
+  it('verifies served content, not just HTTP status', () => {
+    // A re-published article answers 200 from the old bytes for ~40s while the
+    // push propagates; status-only would green-light the search-engine ping on
+    // stale content. Observed live: 42s to converge, 200 throughout.
+    expect(script).toMatch(/createHash\(['"]sha256['"]\)/);
+  });
+});

--- a/tests/fast-publish-workflow-invariants.test.ts
+++ b/tests/fast-publish-workflow-invariants.test.ts
@@ -98,3 +98,35 @@ describe('wait-for-live-article-shards.mjs invariants', () => {
     expect(script).toMatch(/createHash\(['"]sha256['"]\)/);
   });
 });
+
+describe('producer wiring stays connected', () => {
+  // Removing a dispatch step breaks nothing loudly: the article simply falls
+  // back to the 30min-2h deploy and the fast path quietly stops applying to
+  // that producer. Same silent-inert class as everything else in this file.
+  const producers = [
+    '.github/workflows/generate-article.yml',
+    '.github/workflows/publish-journalist-articles.yml',
+  ];
+
+  for (const producer of producers) {
+    it(`${producer} dispatches fast-publish-article.yml`, () => {
+      const yml = read(producer);
+      expect(yml).toContain('fast-publish-article.yml');
+      // Must go through the shared dispatch engine, which is what waits for the
+      // pushed SHA to be visible on main before firing.
+      expect(yml).toMatch(/trigger-workflow\.sh"?\s+"fast-publish-article\.yml"/);
+    });
+  }
+
+  it('the reconciler re-dispatches articles the deploy raced past', () => {
+    const yml = read('.github/workflows/fast-publish-reconcile.yml');
+    // Must key off the deploy build SHA, otherwise it cannot tell which
+    // articles the completed build predates.
+    expect(yml).toContain('workflow_run.head_sha');
+    expect(yml).toContain('reconcile-fast-publish-articles.mjs');
+    // It runs without npm ci, so Remote Config must be reachable without
+    // firebase-admin or it silently loads no GITHUB_PAT and dispatches nothing.
+    expect(yml).not.toMatch(/^\s*run:\s*npm ci\b/m);
+    expect(read('scripts/load-rc-env.mjs')).toContain('fetchTemplateViaRest');
+  });
+});


### PR DESCRIPTION
Difetto trovato osservando la feature appena mergiata (#4869) prima che i suoi percorsi batch venissero esercitati.

## Il problema

`fast-publish-article.yml` serializzava con `group: fast-publish-${{ inputs.section }}`. Il commento dichiarava l'intento corretto — «un run in coda deve comunque completare e pubblicare il suo articolo invece di essere cancellato» — ma il raggruppamento per-sezione non può ottenerlo: **GitHub tiene esattamente un run pendente per gruppo**, quindi un terzo run accodato cancella quello in attesa.

Entrambi i produttori che dispatchano in blocco perdono gli articoli di mezzo, in silenzio:

- `publish-journalist-articles.yml` dispatcha un run per ogni id in `published_ids`, e una singola finestra cron da 15 minuti può pubblicarne diversi;
- `scripts/reconcile-fast-publish-articles.mjs` ne dispatcha uno per articolo registrato dopo la build SHA del deploy — un arretrato per costruzione.

Sono esattamente i due percorsi che esistono per **garantire la completezza**.

È anche la stessa inedia da coda che questa feature è nata per superare: il gruppo `pages-build-run` di `deploy.yml` ha scartato **12 run consecutivi** il 2026-07-28 mentre un articolo aspettava 3h36m per andare live.

## Implementato

- `concurrency.group` passa a `fast-publish-${{ inputs.section }}-${{ inputs.article_id }}`.
- Commento riscritto per spiegare perché il per-sezione non poteva funzionare, così l'intento non torna a divergere dall'implementazione.

Run concorrenti su articoli **diversi** sono sicuri contro lo stesso shard repo: `push-article-shard-incremental.sh` non fa mai force-push e costruisce il commit sul tip remoto, quindi chi perde la corsa riceve un non-fast-forward, ri-clona sul nuovo tip e ricostruisce (comportamento già coperto dal suo test di scrittura concorrente). Due run sullo **stesso** articolo continuano a serializzare, che è l'unica corsa che valga la pena impedire.


- **`tests/fast-publish-workflow-invariants.test.ts`** (nuovo): fissa gli 11 invarianti che una CI verde **non può osservare**. Ogni difetto asserito qui è stato live in qualche momento restando verde, perché la pipeline è deliberatamente fault-tolerant e un fast path rotto degrada in «l'articolo va live col deploy lento» senza che nulla diventi rosso.

  Coperti: concorrenza per-articolo; nessun `npm ci` sul percorso critico; ping ai motori gateato sulla verifica live; identità git prima di `commit-tree`; `write-tree --missing-ok`; mai force-push; User-Agent sulla fetch di contenuto; verifica basata sul contenuto e non sullo stato; dispatch presente in **entrambi** i produttori; e le due precondizioni del riconciliatore (deve agganciarsi alla build SHA del deploy, e `load-rc-env.mjs` deve mantenere il percorso REST senza dipendenze, altrimenti gira senza token e non dispatcha nulla riportando successo).

  **Controlli negativi eseguiti** su tre gate — ripristinare il gruppo per-sezione, rimuovere l'identità git, e cancellare lo step di dispatch da `generate-article.yml` — ciascuno rende rosso il proprio gate. Nessuno passa a vuoto.

## Non implementato (ancora)

Nessuno.

## Validazione

Oltre a YAML + actionlint, entrambe le sezioni sono state esercitate live sul percorso completo dopo il merge di #4869:

- **frontaliere** ([run 30363357294](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/30363357294)): render 0,7s, 4 shard pushati, contenuto verificato live, Google 4/4 e IndexNow 3/3. Dispatch → live **2m29s**.
- **svizzera** ([run 30365047167](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/30365047167)): render 0,3s, 4 shard `articolisvizzera-*` pushati, contenuto verificato live, Google 4/4 e IndexNow 3/3. Questo esercita per la prima volta le 4 deploy-key svizzera e la mappatura `svizzera → articolisvizzera`.

Integrità post-push verificata in produzione su entrambi gli articoli: pagine complete (22-23 KB), 3 blocchi JSON-LD, 5 link hreflang (4 locali + x-default).

