### PR TITLE
perf(fast-publish): stop re-downloading rclone for every uploaded file

### DIFF
--- a/scripts/lib/upload-cdn-file.sh
+++ b/scripts/lib/upload-cdn-file.sh
@@ -110,6 +110,14 @@ _content_type_for() {
 content_type="$(_content_type_for "$local_file")"
 
 rtmp="${RUNNER_TEMP:-/tmp}"
+# An earlier invocation in the same job may have already installed rclone: the
+# `export PATH` below dies with that subshell (each call is its own bash
+# process) but the binary survives on disk. Without this, every uploaded file
+# re-downloads and re-unzips the ~20 MB archive — measured at ~4.5s per file on
+# a path whose entire reason to exist is speed (run 30365047167 paid it twice).
+if [ -x "$rtmp/rclone-bin/rclone" ]; then
+  export PATH="$rtmp/rclone-bin:$PATH"
+fi
 if ! command -v rclone >/dev/null 2>&1; then
   echo "[cdn-upload] rclone not found — installing static binary…"
   if curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \


### PR DESCRIPTION
Difetto osservato leggendo i log del primo run live del fast-publish, non in revisione statica.

## Il problema

`scripts/lib/upload-cdn-file.sh` installa rclone in `$RUNNER_TEMP/rclone-bin` e lo mette in `PATH` con `export`. Ma ogni invocazione dello script è un **processo bash separato**: l'`export` muore con quel processo, mentre il binario resta su disco. Ogni file caricato riscaricava e riestraeva l'archivio da ~20 MB.

Misurato su [run 30365047167](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/30365047167): `rclone not found — installing static binary…` compare **due volte**, ~4,5s ciascuna, su un percorso la cui unica ragione d'essere è la velocità. E scala nel verso sbagliato: il costo cresce con ogni asset aggiunto a `cdnUploads`.

## Implementato

Controllo della posizione su disco prima di decidere se installare. Il commento spiega perché l'`export PATH` non sopravvive, così il difetto non viene reintrodotto.

Verificato per comportamento, non per lettura:

- binario già presente → la riga di installazione **non compare affatto** (0 occorrenze);
- binario rimosso → il percorso di installazione viene raggiunto esattamente come prima (1 occorrenza).

## Non implementato (ancora)

Nessuno.
