### PR TITLE
perf(review): il debounce anti-burst copre l'install di Headroom invece di sommarsi

### DIFF
--- a/.github/workflows/pr-review-loop.yml
+++ b/.github/workflows/pr-review-loop.yml
@@ -112,28 +112,14 @@ jobs:
             { echo "pr_number=$PRN"; echo "should_review=false"; } >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Debounce (#3153): un burst di push rapidi sullo stesso branch (agent
-          # che itera fix in <1min) può produrre PIÙ eventi `tests`-success in
-          # sequenza prima che il precedente abbia esaurito il suo `tests` run —
-          # il `cancel-in-progress` di `tests` (keyed sul ref) elimina già gran
-          # parte, ma una corsa dove ogni push arriva DOPO che il precedente ha
-          # già completato con successo (non cancellato) fa comunque partire una
-          # review Claude per uno SHA che sta per essere superato. Fix: dormi una
-          # finestra breve, poi ricontrolla la head LIVE della PR. Se è già
-          # avanzata oltre lo SHA di questo evento, un push più recente è già
-          # arrivato → il SUO `tests` (gira su OGNI push, niente paths-ignore,
-          # vedi header) farà scattare il proprio resolve/review — bail out qui
-          # non lascia MAI la PR senza review. Se invece la head non è cambiata
-          # (caso normale, non-burst) si prosegue subito dopo i ~25s: costo fisso
-          # di latenza, non un giro di Claude sprecato.
-          echo "Debounce: attesa 25s per assorbire push rapidi in burst prima di invocare Claude..."
-          sleep 25
-          LIVE_SHA=$(gh pr view "$PRN" --repo "$REPO" --json headRefOid --jq '.headRefOid // empty' 2>/dev/null || true)
-          if [ -n "${LIVE_SHA:-}" ] && [ "$LIVE_SHA" != "$RUN_HEAD_SHA" ]; then
-            echo "Debounce: PR #$PRN è avanzata a $LIVE_SHA (questo evento era per $RUN_HEAD_SHA) — un push più recente è già arrivato, la sua run di tests/review se ne occuperà. Skip."
-            { echo "pr_number=$PRN"; echo "should_review=false"; } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # NB: il debounce anti-burst NON è più qui — vive nello step
+          # "Debounce burst pushes" più sotto, dopo l'avvio dell'install di
+          # Headroom in background. Restava in questo step per ragioni storiche
+          # e la sua `sleep 25` era puro tempo aggiunto: misurata a 26s di
+          # "Resolve PR" (run 30372284779) PRIMA del checkout, quindi non
+          # copriva nulla. Spostata dopo l'install bg, gli stessi 25s mascherano
+          # l'install invece di sommarsi — e la finestra di ricontrollo della
+          # head diventa più larga, quindi il debounce assorbe più burst.
           {
             echo "pr_number=$PRN"
             echo "should_review=true"
@@ -427,11 +413,51 @@ jobs:
       # `wait: headroom-install` perché quando lo step bg è saltato (PR non
       # reviewabile) non c'è nessun bg outstanding e `wait-all` è un no-op,
       # mentre attendere per id uno step mai avviato non ha semantica definita.
+      # Debounce anti-burst (#3153), spostato qui da "Resolve PR from tests run".
+      #
+      # Cosa protegge: un burst di push ravvicinati sullo stesso branch (agent
+      # che itera fix in <1min) può produrre PIÙ eventi `tests`-success in
+      # sequenza. Il `cancel-in-progress` di `tests` (keyed sul ref) ne elimina
+      # gran parte, ma una corsa in cui ogni push arriva DOPO che il precedente
+      # ha già concluso con successo fa comunque partire una review Claude per
+      # uno SHA che sta per essere superato. Si dorme una finestra breve e si
+      # ricontrolla la head LIVE: se è avanzata, il `tests` del push più recente
+      # farà scattare la propria review (gira su OGNI push, niente
+      # paths-ignore), quindi uscire qui non lascia MAI la PR senza review.
+      #
+      # Perché QUI e non più nel resolve: identica semantica, ma questi 25s ora
+      # cadono mentre l'install di Headroom lavora in background, invece che da
+      # soli prima del checkout. Misura che ha motivato lo spostamento (run
+      # 30372284779): "Resolve PR" 26s + "Install Headroom (background)" 32s di
+      # cui 30s riassorbiti dal wait — gli step fra install e wait (Setup Node,
+      # re-review guard, tier) durano <2s in totale, quindi non mascheravano
+      # niente. Con il debounce qui la finestra di copertura passa da ~2s a ~27s
+      # e il ricontrollo della head diventa pure più tardivo, cioè più efficace.
+      - name: Debounce burst pushes (recheck PR head)
+        id: debounce
+        if: steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PRN: ${{ steps.resolve.outputs.pr_number }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -uo pipefail
+          echo "Debounce: attesa 25s per assorbire push rapidi in burst prima di invocare Claude..."
+          sleep 25
+          LIVE_SHA=$(gh pr view "$PRN" --repo "$REPO" --json headRefOid --jq '.headRefOid // empty' 2>/dev/null || true)
+          if [ -n "${LIVE_SHA:-}" ] && [ "$LIVE_SHA" != "$RUN_HEAD_SHA" ]; then
+            echo "Debounce: PR #$PRN è avanzata a $LIVE_SHA (questo evento era per $RUN_HEAD_SHA) — un push più recente è già arrivato, la sua run di tests/review se ne occuperà. Skip."
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "superseded=false" >> "$GITHUB_OUTPUT"
+
       - name: Wait for background Headroom install
         wait-all: true
 
       - name: Setup Headroom compression proxy
-        if: steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true'
+        if: steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true' && steps.debounce.outputs.superseded != 'true'
         uses: ./.github/actions/setup-headroom
         with:
           # L'install è già girato in background sopra: qui serve solo far
@@ -443,7 +469,7 @@ jobs:
         # tier `minimal` ha il suo percorso corto (≤6 turni, gh pr view diretto
         # nel prompt) e non legge mai $CTX_DIR — skip per non sprecare 3 gh call
         # a vuoto su ogni PR data/docs-only.
-        if: steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true' && steps.tier.outputs.tier != 'minimal'
+        if: steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true' && steps.tier.outputs.tier != 'minimal' && steps.debounce.outputs.superseded != 'true'
         # Fetch una volta sola, PRIMA che Claude parta, ciò che il prompt gli
         # farebbe rifare turno-per-turno (osservato in 3/3 transcript morti
         # error_max_turns analizzati 2026-07-17: `gh pr view`, `gh pr diff`, il
@@ -482,7 +508,7 @@ jobs:
 
       - name: Run Claude review
         id: claude_review
-        if: steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true'
+        if: steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true' && steps.debounce.outputs.superseded != 'true'
         # Don't let a hard action failure abort the job before the guard below
         # can classify it — the guard decides whether to fail loudly.
         continue-on-error: true
@@ -581,7 +607,7 @@ jobs:
         #    has no `## LGTM` so it won't auto-merge, and it gets re-reviewed on
         #    the next push / by the rescuer once quota recovers. No false-green.
         # `set -uo pipefail` (NOT -e): grep in conditionals must not abort.
-        if: always() && steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true'
+        if: always() && steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true' && steps.debounce.outputs.superseded != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
@@ -633,7 +659,7 @@ jobs:
       - name: Claude usage metrics
         # Solo se la review Claude è effettivamente girata (guard non-skip): a
         # review skippata non c'è execution_file da riassumere.
-        if: always() && steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true'
+        if: always() && steps.resolve.outputs.should_review == 'true' && steps.guard.outputs.skip != 'true' && steps.debounce.outputs.superseded != 'true'
         # Exact token/cost for this run (replaces estimates). Writes a table to
         # the run Step Summary + a grep-able CLAUDE_USAGE line to the log.
         # Best-effort: never fails the job.


### PR DESCRIPTION
Completa la parallelizzazione del job review: l'install di Headroom in background introdotto con #4871 era in ombra dietro quasi nulla, quindi il `wait-all` se lo riprendeva quasi tutto.

## Implementato

**Il debounce anti-burst si sposta dove serve**
- Misura su run 30372284779 (prima review post-#4871): `Install Headroom (background)` **32s**, di cui **30s riassorbiti** da `Wait for background Headroom install`. Gli step fra i due (Setup Node, re-review guard, tier) durano meno di 2s in totale, quindi il background non mascherava niente: guadagno reale ~2s invece dei 63s attesi.
- In parallelo, la `sleep 25` del debounce era ancora dentro `Resolve PR from tests run`, **prima del checkout**, dove era tempo puramente additivo: quello step misurava **26s**.
- Spostando il debounce subito prima del `wait-all`, gli stessi 25s cadono mentre l'install lavora. La finestra di copertura passa da ~2s a ~27s e il `Resolve` torna a ~1s. Atteso: **~25s in meno per review**, senza togliere nulla.
- Effetto collaterale positivo: il ricontrollo della head avviene più tardi, quindi il debounce intercetta **più** push superati di prima, non meno.

**Semantica invariata**
- Il recheck confronta ancora la head live della PR con lo SHA dell'evento ed esce se è avanzata; resta safe perché il `tests` di quel push più recente fa scattare la propria review (gira su ogni push, niente `paths-ignore`), quindi nessuna PR resta senza review.
- L'esito passa ora dall'output `superseded`, su cui gattano i cinque step a valle (start del proxy, prefetch, review Claude, check errore transiente, usage metrics): un evento superato continua a costare **zero quota Claude**.
- Il gate è additivo rispetto a quelli esistenti (`should_review`, `guard.skip`), quindi i percorsi di skip già coperti non cambiano.

## Non implementato (ancora)

Nessuno scope residuo.

**Claim non validabile pre-merge → trigger di revert dichiarato** (AGENTS.md, unvalidated-perf-claim). `pr-review-loop` gira via `workflow_run` e usa **sempre** il file di `main`, quindi questa modifica non è osservabile su una PR: la prima esecuzione sarà una review dopo il merge. Se in quella run `Wait for background Headroom install` non scende sotto ~10s, oppure il job review non cala rispetto ai 237s/331s misurati oggi (run 30372284779 / 30371323496), il commit va revertato — è un singolo commit isolato, il rollback è pulito.

## Test plan

- [x] YAML valido; ordine step verificato: `Install Headroom (background)` → `Debounce burst pushes` → `wait-all` → proxy → Claude.
- [x] Gate `superseded` applicato esattamente ai 5 step a valle, non a `Determine review tier` (che precede il debounce) né allo step debounce stesso.
- [ ] Post-merge, prima review reale: `Resolve PR from tests run` ~1s (non più 26s), `Wait for background Headroom install` sotto ~10s, e nei log ancora `Headroom CCR flags: --no-ccr` + `proxy ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
