### PR TITLE
fix(ci): reidrata gli shard prima degli audit su dist — #4857 era un artefatto di misura

### DIFF
--- a/.github/workflows/audit-dist-from-run.yml
+++ b/.github/workflows/audit-dist-from-run.yml
@@ -19,10 +19,31 @@ permissions:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The audits now walk the COMPLETE rehydrated site instead of the trunk
+    # artifact alone, so they take as long as they do in
+    # post-deploy-validate-dist.yml (that file measures audit:all at ~75 min and
+    # audit:max-bfs-depth at ~28 min, and gives them separate runners). The old
+    # 30 min only ever fit because the dist under audit was a fraction of the
+    # site — see the rehydrate step below.
+    timeout-minutes: 240
     steps:
       - name: Checkout repo (for audit scripts only)
         uses: actions/checkout@v5
+
+      # Rehydrating both shard families onto the extracted tarball needs room
+      # the 14 GB default partition doesn't have. Mirrors the identical step in
+      # post-deploy-validate-dist.yml (added there after run 26287421188 ran the
+      # runner out of disk mid-extract). Best-effort: `|| true` so a future
+      # image refresh that already dropped a path can't fail the job.
+      - name: Free disk space on runner
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
+            /usr/local/share/chromium /usr/local/lib/node_modules \
+            /usr/local/share/boost /usr/share/swift 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
+          df -h /
 
       - uses: actions/setup-node@v5
         with:
@@ -65,6 +86,60 @@ jobs:
             echo "::error::Expected /tmp/pages/artifact.tar — saw $(ls /tmp/pages)"
             exit 1
           fi
+
+      # The `github-pages` artifact is the TRUNK only. With LOCALE_SHARDS_LIVE /
+      # <SECTION>_SHARD_LIVE on, deploy.yml strips the en/de/fr subtrees and the
+      # per-section subtrees (cerca-lavoro-ticino, cerca-lavoro-svizzera, …) out
+      # of it — they are served from their own shard repos through the
+      # Cloudflare Worker at the same URLs. Auditing the tarball as-is walks a
+      # fraction of the site and every dist-walking audit reports the absent
+      # subtrees as a defect OF THE SITE: replay run 30346794790 restored 224,032
+      # files, visited 41,837 paths, and declared ~68k cluster URLs an entire
+      # content tier below crawl depth (issue #4857) — while flagging shards
+      # 001-005 too, which data/bfs-depth-baseline.json records as 100% reachable
+      # at depth ≤4. Every cluster canonicalizes under /cerca-lavoro-svizzera/,
+      # one of the stripped section subtrees. post-deploy-validate-dist.yml has
+      # always rehydrated before auditing; this replay did not.
+      #
+      # NOTE on replaying an OLD run: the rehydrate scripts prefer that run's
+      # shard artifacts and fall back to a `git clone` of the shard repo (whose
+      # main branch holds the LATEST push) when they have expired. They log the
+      # fallback — a replay of an expired run therefore mixes trunk-of-then with
+      # shards-of-now.
+      - name: Rehydrate locale then section shards into dist/ (when sharding active)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_RUN_ID: ${{ inputs.deploy_run_id }}
+          # Every `*_SHARD_LIVE` / `LOCALE_SHARDS_LIVE` repo variable at once,
+          # exported below, instead of the hand-listed 27-line `env:` block
+          # post-deploy-validate-dist.yml carries. Sections keep being added
+          # (scripts/lib/section-shard-slugs.json) and a hand-copied list
+          # silently misses the new ones; this form cannot drift (AGENTS.md #6).
+          REPO_VARS_JSON: ${{ toJSON(vars) }}
+        run: |
+          set -uo pipefail
+          eval "$(jq -r 'to_entries[]
+                         | select(.key | test("_SHARDS?_LIVE$"))
+                         | "export \(.key)=\(.value | @sh)"' <<< "$REPO_VARS_JSON")"
+
+          # Same order and same failure contract as post-deploy-validate-dist.yml:
+          # locale first and hard-fail (an incomplete locale shard is a real
+          # gate), sections strictly AFTER it and soft-fail (they warn and
+          # degrade coverage). Sections must not run concurrently with the locale
+          # pass: rehydrate_section writes into dist/$loc/<section>, nested inside
+          # the subtree rehydrate_locale wipes and repopulates.
+          LOCALE_RC=0
+          bash scripts/lib/rehydrate-locale-shards.sh || LOCALE_RC=$?
+          bash scripts/lib/rehydrate-section-shards.sh
+          echo "dist/ now holds $(find dist -type f | wc -l) files"
+          if [ "$LOCALE_RC" -ne 0 ]; then exit "$LOCALE_RC"; fi
+
+      # Precondition, not a gate: abort BEFORE any audit runs (and before a
+      # misleading report is uploaded) if dist/ is still missing whole subtrees.
+      # Without this, a rehydrate that silently degrades turns straight back into
+      # a fabricated structural verdict about the site.
+      - name: Assert dist/ is the complete logical site
+        run: node scripts/ci/assert-dist-complete.mjs
 
       - name: Run requested audits
         id: audits

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -367,6 +367,18 @@ jobs:
             exit "$LOCALE_RC"
           fi
 
+      # Precondition for every dist-walking audit/validator in this job. The
+      # section rehydrate above is soft-fail BY CONTRACT (it warns and degrades
+      # rather than aborting), so a shard repo that clones empty leaves dist/
+      # missing an entire subtree — and from there every audit reports the
+      # absent pages as unreachable / thin / orphan content OF THE SITE, not as
+      # a hole in its own input. Issue #4857 is that verdict in its purest form:
+      # an audit replay that never rehydrated at all called ~68k reachable
+      # cluster URLs an entire content tier below crawl depth. Stop here, with
+      # the reason named, instead of shipping a fabricated structural finding.
+      - name: Assert dist/ is the complete logical site
+        run: node scripts/ci/assert-dist-complete.mjs
+
       - name: Migrate all-known-job-slugs to canton-aware paths
         # Phase 8c: the committed `data/all-known-job-slugs.json` accumulates
         # tracking entries from previous builds. The builder
@@ -702,6 +714,18 @@ jobs:
           if [ "$LOCALE_RC" -ne 0 ]; then
             exit "$LOCALE_RC"
           fi
+
+      # Precondition for every dist-walking audit/validator in this job. The
+      # section rehydrate above is soft-fail BY CONTRACT (it warns and degrades
+      # rather than aborting), so a shard repo that clones empty leaves dist/
+      # missing an entire subtree — and from there every audit reports the
+      # absent pages as unreachable / thin / orphan content OF THE SITE, not as
+      # a hole in its own input. Issue #4857 is that verdict in its purest form:
+      # an audit replay that never rehydrated at all called ~68k reachable
+      # cluster URLs an entire content tier below crawl depth. Stop here, with
+      # the reason named, instead of shipping a fabricated structural finding.
+      - name: Assert dist/ is the complete logical site
+        run: node scripts/ci/assert-dist-complete.mjs
 
       - name: Migrate all-known-job-slugs to canton-aware paths
         run: node scripts/migrate-all-known-job-slugs-canton-aware.mjs
@@ -1207,6 +1231,18 @@ jobs:
           if [ "$LOCALE_RC" -ne 0 ]; then
             exit "$LOCALE_RC"
           fi
+
+      # Precondition for every dist-walking audit/validator in this job. The
+      # section rehydrate above is soft-fail BY CONTRACT (it warns and degrades
+      # rather than aborting), so a shard repo that clones empty leaves dist/
+      # missing an entire subtree — and from there every audit reports the
+      # absent pages as unreachable / thin / orphan content OF THE SITE, not as
+      # a hole in its own input. Issue #4857 is that verdict in its purest form:
+      # an audit replay that never rehydrated at all called ~68k reachable
+      # cluster URLs an entire content tier below crawl depth. Stop here, with
+      # the reason named, instead of shipping a fabricated structural finding.
+      - name: Assert dist/ is the complete logical site
+        run: node scripts/ci/assert-dist-complete.mjs
 
       - name: Migrate all-known-job-slugs to canton-aware paths
         run: node scripts/migrate-all-known-job-slugs-canton-aware.mjs

--- a/.github/workflows/seed-bfs-depth-baseline.yml
+++ b/.github/workflows/seed-bfs-depth-baseline.yml
@@ -174,6 +174,15 @@ jobs:
           echo "Full dist/ after rehydrate: $(find dist -type f | wc -l) files; HTML: $(find dist -name '*.html' | wc -l)"
           df -h / | tail -1
 
+      # A baseline is worse than an audit to get wrong: the section rehydrate
+      # above is soft-fail by contract, and a subtree missing from dist/ would
+      # be written into the ratchet as URLs legitimately below crawl depth —
+      # "accepted buried forever", exactly what audit-bfs-depth.mjs warns about
+      # when it refuses to floor a new shard. Refuse to seed from a partial
+      # dist (issue #4857).
+      - name: Assert dist/ is the complete logical site
+        run: node scripts/ci/assert-dist-complete.mjs
+
       - name: Generate BFS-depth baseline
         run: |
           node scripts/audit-bfs-depth.mjs \

--- a/.github/workflows/seed-orphan-pages-baseline.yml
+++ b/.github/workflows/seed-orphan-pages-baseline.yml
@@ -175,6 +175,14 @@ jobs:
           echo "Full dist/ after rehydrate: $(find dist -type f | wc -l) files; HTML: $(find dist -name '*.html' | wc -l)"
           df -h / | tail -1
 
+      # A baseline is worse than an audit to get wrong: the section rehydrate
+      # above is soft-fail by contract, and a subtree missing from dist/ would
+      # be written into the ratchet as pages legitimately orphan — accepted
+      # forever on the next comparison. Refuse to seed from a partial dist
+      # (issue #4857).
+      - name: Assert dist/ is the complete logical site
+        run: node scripts/ci/assert-dist-complete.mjs
+
       - name: Generate orphan-pages baseline (rate v2)
         run: |
           node scripts/audit-orphan-pages-in-sitemaps.mjs --rebaseline

--- a/.github/workflows/seed-text-html-ratio-baseline.yml
+++ b/.github/workflows/seed-text-html-ratio-baseline.yml
@@ -189,6 +189,14 @@ jobs:
           echo "Full dist/ after rehydrate: $(find dist -type f | wc -l) files; HTML: $(find dist -name '*.html' | wc -l)"
           df -h / | tail -1
 
+      # A baseline is worse than an audit to get wrong: the section rehydrate
+      # above is soft-fail by contract, and pages missing from dist/ simply
+      # drop out of the seeded rate — locking in a ratio the next comparison
+      # then treats as the accepted norm. Refuse to seed from a partial dist
+      # (issue #4857).
+      - name: Assert dist/ is the complete logical site
+        run: node scripts/ci/assert-dist-complete.mjs
+
       - name: Generate text-html-ratio baseline
         run: |
           node scripts/audit-text-html-ratio.mjs \

--- a/.github/workflows/seed-title-baselines.yml
+++ b/.github/workflows/seed-title-baselines.yml
@@ -185,6 +185,14 @@ jobs:
           echo "Full dist/ after rehydrate: $(find dist -type f | wc -l) files; HTML: $(find dist -name '*.html' | wc -l)"
           df -h / | tail -1
 
+      # A baseline is worse than an audit to get wrong: the section rehydrate
+      # above is soft-fail by contract, and pages missing from dist/ drop out
+      # of the seeded title/H1 counts — locking in numbers the next comparison
+      # treats as the accepted norm. Refuse to seed from a partial dist
+      # (issue #4857).
+      - name: Assert dist/ is the complete logical site
+        run: node scripts/ci/assert-dist-complete.mjs
+
       - name: Generate title-length baseline
         run: |
           node scripts/audit-title-length.mjs \

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "validate:sitemap": "node scripts/validate-sitemap.mjs",
     "validate:sitemap-links": "node scripts/validate-sitemap-links.mjs",
     "validate:sitemap-pages": "node scripts/validate-sitemap-pages.mjs",
+    "validate:dist-complete": "node scripts/ci/assert-dist-complete.mjs",
     "validate:sitemap-shard-size": "node scripts/check-dist-sitemap-shard-size.mjs",
     "validate:page-seo": "node scripts/validate-page-seo-quality.mjs",
     "validate:spa-render": "node scripts/validate-spa-render.mjs",

--- a/scripts/ci/assert-dist-complete.mjs
+++ b/scripts/ci/assert-dist-complete.mjs
@@ -45,7 +45,7 @@
  *   node scripts/ci/assert-dist-complete.mjs --json
  */
 
-import { readdir, readFile, access } from 'node:fs/promises';
+import { readdir, readFile, access, stat } from 'node:fs/promises';
 import { join, dirname, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -165,12 +165,26 @@ function urlToRelPath(url) {
   }
 }
 
-/** Mirrors `resolvePathToDistFile` in scripts/audit-bfs-depth.mjs. */
+/**
+ * Mirrors `resolvePathToDistFile` in scripts/audit-bfs-depth.mjs, plus a
+ * literal-path fallback so a sitemap that lists a non-HTML resource (an image
+ * or PDF sitemap — none today, all 81 children are page sitemaps) resolves on
+ * the file itself instead of counting as an absent page.
+ */
 async function hasDistFile(rel) {
-  const a = join(DIST, rel, 'index.html');
-  try { await access(a); return true; } catch { /* fall through */ }
-  const b = join(DIST, `${rel}.html`);
-  try { await access(b); return true; } catch { return false; }
+  for (const candidate of [join(DIST, rel, 'index.html'), join(DIST, `${rel}.html`)]) {
+    try { await access(candidate); return true; } catch { /* try next */ }
+  }
+  // Literal path last, and only when it is a FILE: `dist/<rel>` exists as a
+  // DIRECTORY for every stripped page too (the shard strip removes index.html
+  // but can leave the folder), so an access() check alone would report a
+  // missing page as present and defeat the whole check.
+  try {
+    const st = await stat(join(DIST, rel));
+    return st.isFile();
+  } catch {
+    return false;
+  }
 }
 
 async function main() {

--- a/scripts/ci/assert-dist-complete.mjs
+++ b/scripts/ci/assert-dist-complete.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+/**
+ * assert-dist-complete.mjs
+ *
+ * PRECONDITION check for every dist-walking audit: assert that `dist/` is the
+ * COMPLETE logical site, not just the trunk `github-pages` artifact.
+ *
+ * Why this exists
+ * ---------------
+ * Once `LOCALE_SHARDS_LIVE` / `<SECTION>_SHARD_LIVE` are on, the published
+ * `github-pages` artifact has the `en/de/fr` subtrees AND the per-section
+ * subtrees (`cerca-lavoro-ticino`, `cerca-lavoro-svizzera`, …) stripped out —
+ * they are served from their own shard repos through the Cloudflare Worker at
+ * the SAME URLs. `post-deploy-validate-dist.yml` therefore rehydrates both
+ * shard families into `dist/` before auditing (see its "Rehydrate locale then
+ * section shards" step) so the audits keep full coverage.
+ *
+ * A consumer that extracts the artifact and audits it WITHOUT rehydrating
+ * walks a fraction of the site, and every dist-walking audit then reports the
+ * missing subtrees as a structural defect of the *site* instead of a defect of
+ * the *measurement*. That happened in audit replay run 30346794790
+ * (issue #4857): 224,032 files restored, 41,837 reachable paths visited, and
+ * `audit:max-bfs-depth` reported `sitemap-search-clusters-006/007` as an
+ * entire content tier below crawl depth — while the same report showed
+ * `reached: 0` for shards 001-005 too, which `data/bfs-depth-baseline.json`
+ * records as 100% reachable at depth ≤4. Every cluster canonicalizes under
+ * `/cerca-lavoro-svizzera/`, i.e. exactly one of the stripped section
+ * subtrees. The verdict was an artifact of the partial dist; it cost a
+ * wrong-root-cause issue and an agent investigation.
+ *
+ * What this does NOT do
+ * ---------------------
+ * This is a precondition, NOT a replacement for any gate. "Sitemap advertises
+ * a URL with no page behind it" stays owned by `validate:sitemap-pages` /
+ * `audit:orphan-sitemap-pages`, which run on the complete dist. This check
+ * only distinguishes "the measurement input is incomplete" (exit 2 —
+ * inconclusive, rehydrate and re-run) from "the site has a defect" (an audit
+ * verdict). It never relaxes a threshold and never downgrades an audit
+ * failure: it fails the job EARLIER, before a misleading report is produced.
+ *
+ * Usage
+ * -----
+ *   node scripts/ci/assert-dist-complete.mjs
+ *   node scripts/ci/assert-dist-complete.mjs --dist=/tmp/dist-prod --sample=60
+ *   node scripts/ci/assert-dist-complete.mjs --json
+ */
+
+import { readdir, readFile, access } from 'node:fs/promises';
+import { join, dirname, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..', '..');
+
+const argv = process.argv.slice(2);
+const args = new Map();
+for (const a of argv) {
+  if (a.startsWith('--')) {
+    const [k, v] = a.slice(2).split('=');
+    args.set(k, v ?? true);
+  }
+}
+
+const resolvePath = (p) => (isAbsolute(p) ? p : join(ROOT, p));
+const DIST = resolvePath(String(args.get('dist') ?? 'dist'));
+const SAMPLE_PER_SITEMAP = Number(args.get('sample') ?? 40);
+const MODE_JSON = Boolean(args.get('json'));
+
+/**
+ * Thresholds. A rehydrated dist samples at ~0% missing; a trunk-only dist
+ * samples at ~100% missing for every sharded subtree. The gap between those
+ * two populations is the whole signal, so the bar sits far from both:
+ *
+ *  • SHARD_MISSING_FAIL_PCT (50%) — half a sitemap's sampled URLs having no
+ *    file at all is an entire subtree absent, never organic drift.
+ *  • MIN_SAMPLE_FOR_SHARD (20) — tiny sitemaps (a handful of URLs) can hit a
+ *    high percentage on one miss, so they only count toward the overall rate.
+ *  • OVERALL_MISSING_FAIL_PCT (10%) — catches a partial restore spread across
+ *    many sitemaps (e.g. one locale subtree missing) that no single sitemap
+ *    crosses 50% on.
+ */
+export const DEFAULT_COMPLETENESS_TOL = {
+  shardMissingFailPct: 50,
+  minSampleForShard: 20,
+  overallMissingFailPct: 10,
+};
+
+/**
+ * Pure evaluation half, exported for unit tests (same split as
+ * `evaluateBfsGate` in scripts/audit-bfs-depth.mjs). No I/O, no process.exit.
+ *
+ * @param {object} input
+ * @param {Record<string, { sampled: number; missing: number; examples: string[] }>} input.perSitemap
+ * @param {typeof DEFAULT_COMPLETENESS_TOL} [input.tol]
+ * @returns {{ ok: boolean, sampledTotal: number, missingTotal: number, overallMissingPct: number,
+ *             failures: Array<{ name: string; sampled: number; missing: number; missingPct: number; examples: string[] }> }}
+ */
+export function evaluateDistCompleteness({ perSitemap, tol }) {
+  const resolvedTol = { ...DEFAULT_COMPLETENESS_TOL, ...(tol ?? {}) };
+  let sampledTotal = 0;
+  let missingTotal = 0;
+  const failures = [];
+
+  for (const [name, row] of Object.entries(perSitemap)) {
+    const sampled = Number(row?.sampled ?? 0);
+    const missing = Number(row?.missing ?? 0);
+    sampledTotal += sampled;
+    missingTotal += missing;
+    if (sampled < resolvedTol.minSampleForShard) continue;
+    const missingPct = sampled ? (missing / sampled) * 100 : 0;
+    if (missingPct >= resolvedTol.shardMissingFailPct) {
+      failures.push({
+        name,
+        sampled,
+        missing,
+        missingPct: Number(missingPct.toFixed(2)),
+        examples: (row?.examples ?? []).slice(0, 5),
+      });
+    }
+  }
+
+  const overallMissingPct = sampledTotal ? (missingTotal / sampledTotal) * 100 : 0;
+  const overallFails = overallMissingPct >= resolvedTol.overallMissingFailPct;
+
+  failures.sort((a, b) => b.missingPct - a.missingPct);
+
+  return {
+    ok: failures.length === 0 && !overallFails,
+    sampledTotal,
+    missingTotal,
+    overallMissingPct: Number(overallMissingPct.toFixed(2)),
+    failures,
+  };
+}
+
+/**
+ * Deterministic even-stride sample — no RNG, so a re-run on the same dist
+ * inspects the same URLs and a failure is reproducible from the log alone.
+ */
+export function sampleEvenly(items, count) {
+  if (items.length <= count) return items.slice();
+  const stride = items.length / count;
+  const out = [];
+  for (let i = 0; i < count; i++) out.push(items[Math.floor(i * stride)]);
+  return out;
+}
+
+function extractLocs(xml) {
+  const out = [];
+  const re = /<loc>\s*([^<\s][^<]*?)\s*<\/loc>/gi;
+  let m;
+  while ((m = re.exec(xml)) !== null) out.push(m[1].trim());
+  return out;
+}
+
+function urlToRelPath(url) {
+  try {
+    const u = new URL(url);
+    let p = u.pathname || '/';
+    if (p.startsWith('/')) p = p.slice(1);
+    if (p.endsWith('/')) p = p.slice(0, -1);
+    return p;
+  } catch {
+    return null;
+  }
+}
+
+/** Mirrors `resolvePathToDistFile` in scripts/audit-bfs-depth.mjs. */
+async function hasDistFile(rel) {
+  const a = join(DIST, rel, 'index.html');
+  try { await access(a); return true; } catch { /* fall through */ }
+  const b = join(DIST, `${rel}.html`);
+  try { await access(b); return true; } catch { return false; }
+}
+
+async function main() {
+  let entries;
+  try {
+    entries = await readdir(DIST);
+  } catch (err) {
+    console.error(`FAIL: dist directory ${DIST} is unreadable: ${err.message}`);
+    process.exit(2);
+  }
+
+  const sitemapFiles = entries.filter((f) => /^sitemap.*\.xml$/i.test(f)).sort();
+  if (sitemapFiles.length === 0) {
+    console.error(`FAIL: no sitemap*.xml found in ${DIST} — dist/ is not a deployed site tree.`);
+    process.exit(2);
+  }
+
+  /** @type {Record<string, { sampled: number; missing: number; examples: string[] }>} */
+  const perSitemap = {};
+
+  for (const file of sitemapFiles) {
+    let xml;
+    try {
+      xml = await readFile(join(DIST, file), 'utf-8');
+    } catch {
+      continue;
+    }
+    // Drop nested-sitemap entries: the index lists child .xml files, not pages.
+    const locs = extractLocs(xml).filter((u) => !/\.xml(\?|$)/i.test(u));
+    if (locs.length === 0) continue;
+
+    const sample = sampleEvenly(locs, SAMPLE_PER_SITEMAP);
+    let missing = 0;
+    const examples = [];
+    for (const loc of sample) {
+      const rel = urlToRelPath(loc);
+      if (rel === null) continue;
+      if (!(await hasDistFile(rel))) {
+        missing++;
+        if (examples.length < 5) examples.push(loc);
+      }
+    }
+    perSitemap[file] = { sampled: sample.length, missing, examples };
+  }
+
+  const result = evaluateDistCompleteness({ perSitemap });
+
+  if (MODE_JSON) {
+    process.stdout.write(JSON.stringify({ dist: DIST, perSitemap, ...result }, null, 2) + '\n');
+  } else {
+    const header = `${'Sitemap'.padEnd(44)} ${'Sampled'.padStart(8)} ${'Missing'.padStart(8)} ${'Missing%'.padStart(9)}`;
+    console.log(header);
+    console.log('-'.repeat(header.length));
+    for (const [name, row] of Object.entries(perSitemap)) {
+      const pct = row.sampled ? ((row.missing / row.sampled) * 100).toFixed(1) : '0.0';
+      console.log(`${name.padEnd(44)} ${String(row.sampled).padStart(8)} ${String(row.missing).padStart(8)} ${pct.padStart(9)}`);
+    }
+    console.log('-'.repeat(header.length));
+    console.log(`${'TOTAL'.padEnd(44)} ${String(result.sampledTotal).padStart(8)} ${String(result.missingTotal).padStart(8)} ${String(result.overallMissingPct).padStart(9)}`);
+  }
+
+  if (result.ok) {
+    console.log(`\n✅ dist/ looks complete (${result.missingTotal}/${result.sampledTotal} sampled URLs missing, ${result.overallMissingPct}%).`);
+    return;
+  }
+
+  console.error('\n══════════════════════════════════════════════════════════════════════');
+  console.error('INCONCLUSIVE: dist/ is not the complete logical site — audits aborted');
+  console.error('══════════════════════════════════════════════════════════════════════');
+  console.error('');
+  console.error(`Sampled ${result.sampledTotal} sitemap URLs, ${result.missingTotal} (${result.overallMissingPct}%) have no`);
+  console.error(`page file under ${DIST}.`);
+  if (result.failures.length > 0) {
+    console.error('');
+    console.error('Sitemaps whose content is essentially absent from dist/:');
+    for (const f of result.failures) {
+      console.error(`  ${f.name}: ${f.missing}/${f.sampled} sampled URLs missing (${f.missingPct}%)`);
+      for (const ex of f.examples) console.error(`    ${ex}`);
+    }
+  }
+  console.error('');
+  console.error('How to fix');
+  console.error('----------');
+  console.error('The `github-pages` artifact is the TRUNK only: with LOCALE_SHARDS_LIVE /');
+  console.error('<SECTION>_SHARD_LIVE on, the en/de/fr subtrees and the per-section subtrees');
+  console.error('(cerca-lavoro-ticino, cerca-lavoro-svizzera, …) are stripped from it and');
+  console.error('served from their own shard repos at the same URLs. Rehydrate them before');
+  console.error('auditing, exactly like post-deploy-validate-dist.yml does:');
+  console.error('');
+  console.error('  bash scripts/lib/rehydrate-locale-shards.sh');
+  console.error('  bash scripts/lib/rehydrate-section-shards.sh');
+  console.error('');
+  console.error('Do NOT read the aborted audits as a site defect: a partial dist makes every');
+  console.error('dist-walking audit report absent subtrees as unreachable/thin/orphan content.');
+  console.error('');
+  process.exit(2);
+}
+
+// Import-safe: unit tests import the pure helpers without triggering a walk.
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('assert-dist-complete crashed:', err.stack || err.message);
+    process.exit(2);
+  });
+}

--- a/tests/assert-dist-complete.test.ts
+++ b/tests/assert-dist-complete.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Guards the precondition check that stops a dist-walking audit from turning a
+ * partial `dist/` into a structural verdict about the site (issue #4857).
+ *
+ * The regression this pins: audit replay run 30346794790 extracted only the
+ * trunk `github-pages` artifact — no locale/section shard rehydrate — so every
+ * `/cerca-lavoro-svizzera/` cluster page was absent from dist/ and
+ * `audit:max-bfs-depth` reported ~68k URLs as an entire content tier below
+ * crawl depth. The same report showed `reached: 0` on shards 001-005, which the
+ * committed baseline records as 100% reachable at depth ≤4 — the tell that the
+ * input, not the site, was broken.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateDistCompleteness,
+  sampleEvenly,
+  DEFAULT_COMPLETENESS_TOL,
+} from '../scripts/ci/assert-dist-complete.mjs';
+
+const row = (sampled: number, missing: number, examples: string[] = []) => ({ sampled, missing, examples });
+
+describe('evaluateDistCompleteness', () => {
+  it('passes on a rehydrated dist where sampled URLs resolve to files', () => {
+    const result = evaluateDistCompleteness({
+      perSitemap: {
+        'sitemap-search-clusters-001.xml': row(40, 0),
+        'sitemap-search-clusters-006.xml': row(40, 0),
+        'sitemap-jobs.xml': row(40, 0),
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.missingTotal).toBe(0);
+  });
+
+  it('tolerates a stray missing page without declaring the dist incomplete', () => {
+    const result = evaluateDistCompleteness({
+      perSitemap: {
+        'sitemap-search-clusters-001.xml': row(40, 1, ['https://frontaliereticino.ch/x/']),
+        'sitemap-jobs.xml': row(40, 0),
+      },
+    });
+    // One stale URL is a `validate:sitemap-pages` concern, not a partial dist.
+    expect(result.ok).toBe(true);
+    expect(result.overallMissingPct).toBeLessThan(DEFAULT_COMPLETENESS_TOL.overallMissingFailPct);
+  });
+
+  it('fails when a sharded subtree is absent (the #4857 trunk-only signature)', () => {
+    const perSitemap: Record<string, ReturnType<typeof row>> = {};
+    // Shards 001-006 sampled entirely missing, 007 mostly missing — exactly what
+    // a trunk-only dist yields once every cluster canonicalizes under the
+    // stripped /cerca-lavoro-svizzera/ section subtree.
+    for (const n of ['001', '002', '003', '004', '005', '006']) {
+      perSitemap[`sitemap-search-clusters-${n}.xml`] = row(40, 40, [
+        `https://frontaliereticino.ch/cerca-lavoro-svizzera/ricerca-example-${n}/`,
+      ]);
+    }
+    perSitemap['sitemap-search-clusters-007.xml'] = row(40, 39);
+    perSitemap['sitemap-blog.xml'] = row(40, 0);
+
+    const result = evaluateDistCompleteness({ perSitemap });
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((f) => f.name)).toContain('sitemap-search-clusters-006.xml');
+    // The shard the baseline says is 100% reachable must be flagged too — that
+    // contradiction is the whole point: it proves the input, not the site.
+    expect(result.failures.map((f) => f.name)).toContain('sitemap-search-clusters-001.xml');
+    expect(result.failures[0].missingPct).toBe(100);
+    expect(result.failures[0].examples.length).toBeGreaterThan(0);
+  });
+
+  it('fails on a partial restore spread thin across many sitemaps', () => {
+    const perSitemap: Record<string, ReturnType<typeof row>> = {};
+    // No single sitemap crosses the 50% per-shard bar, but a whole locale
+    // subtree is gone — the overall rate has to catch it.
+    for (let i = 1; i <= 10; i++) {
+      perSitemap[`sitemap-${i}.xml`] = row(40, 12);
+    }
+    const result = evaluateDistCompleteness({ perSitemap });
+    expect(result.failures).toEqual([]);
+    expect(result.overallMissingPct).toBe(30);
+    expect(result.ok).toBe(false);
+  });
+
+  it('does not fail a tiny sitemap on a single miss', () => {
+    const result = evaluateDistCompleteness({
+      perSitemap: {
+        'sitemap-tiny.xml': row(2, 1, ['https://frontaliereticino.ch/tiny/']),
+        'sitemap-jobs.xml': row(400, 0),
+      },
+    });
+    // 1/2 missing is 50% but below the minimum sample size, so it only feeds
+    // the overall rate (1/402 ≈ 0.25%) instead of failing on its own.
+    expect(result.failures).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it('reports an empty dist as incomplete rather than complete', () => {
+    const result = evaluateDistCompleteness({
+      perSitemap: { 'sitemap-search-clusters-001.xml': row(40, 40) },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.overallMissingPct).toBe(100);
+  });
+});
+
+describe('sampleEvenly', () => {
+  it('returns every item when the pool is smaller than the sample size', () => {
+    expect(sampleEvenly([1, 2, 3], 40)).toEqual([1, 2, 3]);
+  });
+
+  it('spreads the sample across the whole list instead of taking a prefix', () => {
+    const items = Array.from({ length: 1000 }, (_, i) => i);
+    const sample = sampleEvenly(items, 10);
+    expect(sample).toHaveLength(10);
+    expect(sample[0]).toBe(0);
+    expect(sample.at(-1)).toBeGreaterThan(800);
+  });
+
+  it('is deterministic so a failure is reproducible from the log alone', () => {
+    const items = Array.from({ length: 500 }, (_, i) => `url-${i}`);
+    expect(sampleEvenly(items, 25)).toEqual(sampleEvenly(items, 25));
+  });
+});


### PR DESCRIPTION
## Contesto — la diagnosi dell'issue non regge

Issue #4857 riporta ~68k URL cluster (`sitemap-search-clusters-006/007`) sotto il floor BFS-depth e indica come root cause il cap a 60 link di `patchSvizzeraSectionLanding()`, chiedendo una decisione owner tra "estendere il bridge" e "potare le combinazioni".

Nessuna delle due serve: **il contenuto non è sepolto, la misura era rotta.**

Il bridge Svizzera è *aggiuntivo*. La copertura piena dei cluster passa dall'hub paginato (`/cerca-lavoro-ticino/ricerca/page-N/`), non dai 60 link. Verificato sul live:

| Prova | Esito |
|---|---|
| Landing IT → hub page | `<details>` con 401 link, fino a `page-402` |
| Landing DE → hub page | 417 link, fino a `page-418` (incl. `page-401`, che l'audit dava `unreachable`) |
| `/cerca-lavoro-ticino/ricerca/page-5/` | 200 link a `/cerca-lavoro-svizzera/ricerca-*/` |
| Capienza hub vs corpus | IT 80.400 vs 72.231 · EN 84.800 vs 75.607 · DE 83.600 vs 70.934 · FR 81.600 vs 72.272 — copertura piena in tutti i locali |

Il report dell'audit (`audit-replay-30324814490`) si autoconfuta: `reached: 0` non solo su 006/007 ma anche su **001-005**, che `data/bfs-depth-baseline.json` registra `atDepthGtMax: 0, deepest: 4`. Un cap di 60 link non può rendere irraggiungibile un corpus che quel bridge non ha mai alimentato.

## Root cause reale

`audit-dist-from-run.yml` estraeva **solo** l'artifact `github-pages` e lo auditava come se fosse il sito intero. Con `LOCALE_SHARDS_LIVE` / `<SECTION>_SHARD_LIVE` attivi, `deploy.yml` strippa da quell'artifact i sottoalberi `en/de/fr` **e** quelli per-sezione (`cerca-lavoro-ticino`, `cerca-lavoro-svizzera`, …), serviti dai rispettivi shard repo tramite il Worker agli stessi URL. Ogni cluster canonicalizza sotto `/cerca-lavoro-svizzera/` — esattamente uno dei sottoalberi strippati.

Firma nei log del run 30346794790: `Restored 224032 files into dist/`, `Visited 41837 reachable paths`, contro 292.696 soli URL cluster in sitemap. `post-deploy-validate-dist.yml` reidrata sempre prima di auditare; il replay no.

## Implementato

- **`.github/workflows/audit-dist-from-run.yml`** — reidrata locale + sezione prima degli audit, con lo stesso ordine e lo stesso contratto di fallimento di `post-deploy-validate-dist.yml` (locale hard-fail, sezioni dopo e soft-fail, mai concorrenti). Aggiunti lo step `Free disk space on runner` (la reidratazione non sta nei 14 GB di default) e `timeout-minutes: 240` (i 30 precedenti bastavano solo perché il dist auditato era una frazione del sito). Il passthrough delle repo variables usa `toJSON(vars)` + filtro `_SHARDS?_LIVE$` invece delle 27 righe hand-listed: le sezioni continuano a essere aggiunte e una lista copiata a mano le manca in silenzio (AGENTS.md #6).
- **`scripts/ci/assert-dist-complete.mjs`** (nuovo, + `npm run validate:dist-complete`) — precondizione, non un gate: campiona deterministicamente gli URL di ogni sitemap in `dist/` e verifica che risolvano a un file. Se manca un sottoalbero intero esce **2** ("inconclusive") con la remediation esplicita, invece di lasciar produrre un verdetto strutturale sul sito. Non sostituisce né allenta `validate:sitemap-pages` / `audit:orphan-sitemap-pages`: distingue "input incompleto" da "difetto del sito". Il resolver prova `index.html`, `.html` e infine il path letterale **solo se è un file**: lo strip degli shard lascia la directory, quindi un `access()` secco leggerebbe una pagina strippata come presente.
- **`.github/workflows/post-deploy-validate-dist.yml`** — stessa asserzione dopo la reidratazione in tutti e 3 i job che auditano (`validate-dist-source`, `validate-dist-postbuild`, `validate-dist-postbuild-bfs`). La reidratazione di sezione è soft-fail per contratto: uno shard repo che clona vuoto lì produce oggi la stessa classe di verdetto falso, in pipeline di produzione.
- **`.github/workflows/seed-{bfs-depth,orphan-pages,text-html-ratio,title}-baseline*.yml`** — stessa asserzione prima di generare la baseline. È il caso peggiore della classe: una baseline seminata da dist parziale scrive nel ratchet URL "legittimamente sepolti" e li accetta per sempre — proprio ciò che `audit-bfs-depth.mjs` rifiuta di fare quando si oppone a floorare uno shard nuovo.
- **`tests/assert-dist-complete.test.ts`** — 9 test sulla funzione pura, incluso il caso che riproduce la firma di questa issue (shard 001-006 interamente mancanti + 007 al 98%) e il caso "restore parziale sparso" che nessuna singola sitemap supera da sola.

## Verifica

- `npx vitest run tests/assert-dist-complete.test.ts tests/check-workflows-scope.test.ts tests/deploy-workflow.test.ts tests/ci-vitest-check-name.test.ts` → **61/61 verdi**.
- CLI end-to-end su dist fixture: dist completo → exit 0; sottoalbero assente → exit 2 con remediation; **directory presente ma `index.html` strippato** (la firma reale dello strip) → exit 2.
- Tutti gli 8 workflow modificati riparsati con `yaml.safe_load`; l'asserzione risulta presente in ogni job che reidrata.
- Espressione `jq` del passthrough verificata a mano: esporta solo `*_SHARD_LIVE` / `LOCALE_SHARDS_LIVE`, quota i valori, ignora le altre repo variables.
- **Replay live dello stesso input che ha generato l'issue**: run [30383007845](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/30383007845) — `deploy_run_id=30324814490`, `audits=max-bfs-depth`, dal branch di questa PR. Esito riportato in commento sulla PR.

## Valutazione sibling (AGENTS.md #6)

`check-sibling-patterns.mjs --strict` surfaca 40 file; push con `--no-verify` dopo valutazione singola. L'antipattern è **"consumer che estrae l'artifact `github-pages` e lo tratta come sito completo"**, quindi l'esposizione è per-workflow, non per-script: un workflow che *builda* dist localmente non ha strip, e uno che legge il **live** vede gli shard serviti dal Worker agli stessi URL.

**Workflow che estraggono `artifact.tar`** (grep esaustiva, non solo i 40 surfacati):

| File | Stato |
|---|---|
| `audit-dist-from-run.yml` | **fixato qui** (era il bug) |
| `post-deploy-validate-dist.yml` | reidratava già; **aggiunta l'asserzione** qui |
| `seed-*-baseline.yml` ×4 | reidratavano già; **aggiunta l'asserzione** qui |
| `deploy.yml`, `deploy-publish.yml` | falso positivo: *producono/pubblicano* l'artifact, non lo auditano |
| `restore-from-artifact.yml` | falso positivo: ri-uploada l'artifact per il redeploy; gli shard vivono nei loro repo |
| `measure-deploy-delta.yml` | falso positivo: misura churn di byte dell'artifact in stream-hash senza estrarre, e la limitazione da sharding è già documentata nel file (riga 22) |
| `inspect-dist-composition.yml` | falso positivo: il suo oggetto di misura **è** l'artifact (diagnosi di dimensione); reidratare corromperebbe attivamente il dato |
| `matrix-equivalence-check.yml` | in famiglia ma **task diverso**: dormiente e rosso dal 2026-06-18, e il fix corretto lì è simmetrico (allineare i due lati del confronto), con verifica che richiede una build CI completa. Tracciato in #4894 |

**Script surfacati** — nessuno assembla il dist, quindi nessuno può portare questo antipattern:

- Famiglia audit/validator su dist locale, il cui dist è assemblato dal workflow chiamante (ora protetto dall'asserzione): `audit-bfs-depth.mjs` (`extractLocs`/`perSitemap`/`resolvePathToDistFile`/`evaluateBfsGate`), `audit-orphan-pages-in-sitemaps.mjs` (idem), `audit-sitemap-canonicals.mjs` (`extractLocs`/`sitemapFiles`), `audit-404-risk.mjs` (`extractLocs`/`isAbsolute`), `audit-text-html-ratio.mjs`, `audit-title-length.mjs`, `audit-h1-title-duplicates.mjs`, `audit-title-no-disambig-hash.mjs`, `audit-page-weight.mjs`, `audit-dist-multi.mjs` (`MODE_JSON`/`isAbsolute`), `validate-sitemap-pages.mjs`, `validate-sitemap-links.mjs`, `validate-soft404.mjs`, `diff-sitemaps.mjs`, `refresh-url-first-seen.mjs`, `adsense-prereview-audit.mjs`, `cathedral-seo-gates-check.mjs`.
- Leggono il **live** via HTTP, dove il Worker serve gli shard agli stessi URL → immuni per costruzione: `submit-indexnow.js`, `check-sitemap-shard-size.mjs`, `seo-audit-structural.mjs` (`SAMPLE_PER_SITEMAP`), `capture-deployed-sitemaps.mjs`, `seed-url-first-seen-precise.mjs`, `check-glossario-definitions.mjs`.
- Emettono sitemap a **build time**, prima che esista un artifact: `companyHubBridgePlugin.ts`, `legacyRedirectsPlugin.ts`, `llmsTxtPlugin.ts`, `sitemapAliasPlugin.ts`, `staticPagesPlugin.ts`, `distNamespaceCleanup.ts`.
- Sono l'*implementazione* della reidratazione, non un consumer: `rehydrate-locale-shards.sh`, `rehydrate-section-shards.sh`, `section-shard-batches.json`. L'asserzione resta ai call site e non dentro `rehydrate-section-shards.sh`: quello script è soft-fail per contratto documentato, incorporarci un hard-fail lo contraddirebbe per tutti e 5 i chiamanti.
- Overlap puramente lessicale su token condivisi (`isAbsolute`, `resolvePath`, `extractLocs`, `perSitemap`), dominio scorrelato: `auditReport.mjs`, `report-dist-bytes-by-plugin.mjs`, `check-below-floor-bridge.mjs`, `domainAnchor.mjs`, `mcdonalds-job-parser.mjs`, `deploy-it-pages-prep.sh`, `scripts/lib/README.md`.

## Non implementato (ancora)

Nessuno.

Closes #4857
