### PR TITLE
fix(ci): heap esplicito ai walker full-dist (replay + seeder baseline)

### DIFF
--- a/.github/workflows/audit-dist-from-run.yml
+++ b/.github/workflows/audit-dist-from-run.yml
@@ -143,6 +143,17 @@ jobs:
 
       - name: Run requested audits
         id: audits
+        env:
+          # The dist under audit is now the COMPLETE site, not the trunk, and a
+          # full-tree BFS walk holds a Map entry per discovered path. On the
+          # default heap that OOMs: run 30383007845 (the first replay after the
+          # rehydrate fix) died with `FATAL ERROR: Reached heap limit`, rc=134,
+          # before producing any verdict. post-deploy-validate-dist.yml has
+          # always run these walkers with an explicit heap — 8192 for
+          # audit:max-bfs-depth / audit:orphan-sitemap-pages, 4096 for
+          # audit:all. Same runner class here, and the loop below runs them one
+          # at a time, so take the larger of the two for the whole step.
+          NODE_OPTIONS: '--max-old-space-size=8192'
         run: |
           set +e
           IFS=',' read -ra AUDITS <<< "${{ inputs.audits }}"

--- a/.github/workflows/seed-bfs-depth-baseline.yml
+++ b/.github/workflows/seed-bfs-depth-baseline.yml
@@ -56,6 +56,13 @@ jobs:
     # the same-run tar artifacts are missing, so give it the same headroom
     # (mirrors seed-text-html-ratio-baseline.yml's fix for issue #3104).
     timeout-minutes: 60
+    # audit-bfs-depth.mjs walks the whole rehydrated tree and holds a Map entry
+    # per discovered path; on the default heap that OOMs (`FATAL ERROR: Reached
+    # heap limit`, rc=134 — observed in replay run 30383007845 on a complete
+    # dist). post-deploy-validate-dist.yml runs this same walker at 8192; mirror
+    # it here rather than let a manual reseed die mid-walk (issue #4857).
+    env:
+      NODE_OPTIONS: '--max-old-space-size=8192'
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/seed-orphan-pages-baseline.yml
+++ b/.github/workflows/seed-orphan-pages-baseline.yml
@@ -57,6 +57,11 @@ jobs:
     # the same-run tar artifacts are missing, so give it the same headroom
     # (mirrors seed-text-html-ratio-baseline.yml's fix for issue #3104).
     timeout-minutes: 60
+    # audit-orphan-pages-in-sitemaps.mjs is the other full-dist-tree walker, and
+    # post-deploy-validate-dist.yml runs it at 8192 alongside audit:max-bfs-depth.
+    # Default heap OOMs on a complete dist (issue #4857).
+    env:
+      NODE_OPTIONS: '--max-old-space-size=8192'
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/seed-text-html-ratio-baseline.yml
+++ b/.github/workflows/seed-text-html-ratio-baseline.yml
@@ -72,6 +72,12 @@ jobs:
     # legs per post-deploy-validate-dist.yml's own measured worst case) when
     # the same-run tar artifacts are missing, so give it the same headroom.
     timeout-minutes: 60
+    # Same walker family as the audits in post-deploy-validate-dist.yml, which
+    # runs audit-text-html-ratio inside `npm run audit:all` at 4096. Mirror that
+    # here so a manual reseed on a complete dist can't die on the default heap
+    # (issue #4857).
+    env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/seed-title-baselines.yml
+++ b/.github/workflows/seed-title-baselines.yml
@@ -67,6 +67,13 @@ jobs:
     # title-length scan alone before the step-2 scan got cut off mid-run.
     # 280 assumes ~47min setup + ~75min/scan × 3 ≈ 272min, with headroom.
     timeout-minutes: 280
+    # Same walker family as the audits in post-deploy-validate-dist.yml, which
+    # runs audit-title-length / audit-title-no-disambig-hash /
+    # audit-h1-title-duplicates inside `npm run audit:all` at 4096. Mirror that
+    # here so a manual reseed on a complete dist can't die on the default heap
+    # (issue #4857).
+    env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Contesto

PR concatenata su #4895, stesso task (#4857). Quella PR ha corretto **cosa** viene auditato (dist completo invece del solo artifact trunk). Questa corregge **con quali risorse**: il primo replay dopo il fix, run [30383007845](https://github.com/valerielinc-ops/frontaliere-si-o-no/actions/runs/30383007845), ha reidratato correttamente e superato l'asserzione di completezza, poi è morto nell'audit:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
❌ FAIL audit:max-bfs-depth rc=134
```

Nessun verdetto prodotto. Il walk BFS tiene una entry di Map per ogni path scoperto: sul trunk (224k file) stava nell'heap di default, sul sito completo no.

`post-deploy-validate-dist.yml` ha sempre dato a questi walker un heap esplicito — 8192 per `audit:max-bfs-depth` e `audit:orphan-sitemap-pages` (righe 1264-1265), 4096 per la famiglia `audit:all` (riga 747). Il replay girava senza.

## Implementato

- **`.github/workflows/audit-dist-from-run.yml`** — `NODE_OPTIONS: '--max-old-space-size=8192'` sullo step degli audit. Gli audit del loop girano uno alla volta e il runner è della stessa classe di quello che regge 8192 in `validate-dist-postbuild-bfs`, quindi prendo il maggiore dei due valori della pipeline invece di differenziarlo per audit.
- **`seed-bfs-depth-baseline.yml`, `seed-orphan-pages-baseline.yml`** — `NODE_OPTIONS: '--max-old-space-size=8192'` a livello job. Girano esattamente gli stessi due walker full-tree, senza alcun heap impostato: su un dist completo abortiscono come il replay, e una baseline è proprio ciò che non deve morire a metà walk.
- **`seed-text-html-ratio-baseline.yml`, `seed-title-baselines.yml`** — `NODE_OPTIONS: '--max-old-space-size=4096'` a livello job, il valore che la pipeline già usa per questi stessi audit dentro `npm run audit:all`.

Nessun valore inventato: sono i due valori che `post-deploy-validate-dist.yml` applica oggi agli stessi script.

## Verifica

- Tutti e 5 i workflow riparsati con `yaml.safe_load`; heap risolto come atteso (job env per i 4 seeder, step env per il replay).
- Sweep dei workflow che eseguono un walker full-dist: restano senza `NODE_OPTIONS` solo `audit:no-merge-markers` (scansione sorgenti), `audit:job-locations` e `audit:active-jobs-regression` (controlli sui dati job) — nessuno cammina l'albero di `dist/`, quindi fuori classe.
- Replay rilanciato dal branch di questa PR sullo stesso input dell'issue (`deploy_run_id=30324814490`, `audits=max-bfs-depth`): esito riportato in commento qui e su #4857. È la verifica che chiude il cerchio — finora il replay non ha mai prodotto un verdetto BFS su un dist completo.

## Non implementato (ancora)

Nessuno.
