### PR TITLE
fix(border): keyword-preserving title cascade (#4886) + slug collision fix (#4890)

### DIFF
--- a/build-plugins/borderWaitData.ts
+++ b/build-plugins/borderWaitData.ts
@@ -31,7 +31,8 @@ export type BorderWaitLocale = 'it' | 'en' | 'de' | 'fr';
  * itself imports from this module.
  *
  * New crossing → add its slug here (must equal
- * `slugifyCrossingName(crossing.name)` from `data/borderCrossings.ts`). See
+ * `slugifyCrossingName(crossing.name)` from `services/borderCrossingSlug.ts`,
+ * the single source of truth every caller now imports). See
  * the full "Adding a new crossing" checklist above `BorderCrossingRegion`
  * below for every other map that also needs an entry.
  */
@@ -79,8 +80,8 @@ export type BorderCrossingSlug =
  *  3. Add the region to BORDER_WAIT_REGIONS (below) — only if new.
  *  4. Add the crossing's slug to BorderCrossingSlug (below this block) —
  *     must equal `slugifyCrossingName(crossing.name)` from
- *     `data/borderCrossings.ts` (same slugify implementation, see
- *     `services/borderCrossingSlug.ts`).
+ *     `services/borderCrossingSlug.ts` — the one implementation every
+ *     caller imports (no per-file copies remain).
  *  5. Add the slug to BORDER_WAIT_CROSSINGS (below).
  *  6. Add a display-name entry to BORDER_CROSSING_DISPLAY.
  *  7. Add a region entry to CROSSING_TO_REGION.

--- a/build-plugins/borderWaitPagesPlugin.ts
+++ b/build-plugins/borderWaitPagesPlugin.ts
@@ -75,6 +75,7 @@ import {
   BORDER_WAIT_HYDRATION_SCRIPT_TAG,
 } from './borderWaitHydrationScript';
 import { borderCrossings, type BorderCrossing, type WebcamRef } from '../data/borderCrossings';
+import { slugifyCrossingName } from '../services/borderCrossingSlug';
 import { cleanNamespaces, cleanSitemapFiles } from './shared/distNamespaceCleanup';
 import { adSlotHtml } from './lib/adSlotHtml';
 import { imageObjectLdDocument } from '../services/seo/imageObjectLd';
@@ -344,27 +345,8 @@ export function renderTrafficFluidBanner(
 /** Look up crossing static metadata from the registry (matches on slug). */
 function crossingRegistry(slug: BorderCrossingSlug): BorderCrossing | undefined {
   return borderCrossings.find(
-    (c) => slugifyName(c.name) === slug,
+    (c) => slugifyCrossingName(c.name) === slug,
   );
-}
-
-/**
- * Mirror of functions/src/borderCrossingsData.js#slugifyCrossingName.
- * Must stay in sync with that implementation — the Firestore document IDs
- * depend on it.
- * - Strips parentheses + their content (so "Gaggiolo (Cantello-Stabio)" → "gaggiolo")
- * - Removes combining diacritics
- * - Collapses non-alphanumerics into dashes
- */
-function slugifyName(name: string): string {
-  return name
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/\([^)]*\)/g, '')
-    .replace(/[^a-zA-Z0-9]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-    .toLowerCase();
 }
 
 // Color tokens — CSS custom properties so dark mode works automatically.

--- a/build-plugins/fiscalMunicipalityPagesPlugin.ts
+++ b/build-plugins/fiscalMunicipalityPagesPlugin.ts
@@ -60,6 +60,23 @@ const OG_LOCALE: Record<FiscalLocale, string> = {
   fr: 'fr_CH',
 };
 
+// <title> cascade fallback tiers (issue #4886) — literal substrings of each
+// locale's `title` template above, reused so the cascade never has to
+// invent wording. See the `titleCandidates` comment near composePlaceTitle
+// below for why the bare comune name is never an acceptable last resort.
+const TITLE_KEYWORD_TAIL: Record<FiscalLocale, string> = {
+  it: 'tasse frontaliere',
+  en: 'cross-border tax',
+  de: 'Grenzgänger-Steuern',
+  fr: 'impôts frontaliers',
+};
+const TITLE_COLON: Record<FiscalLocale, string> = {
+  it: ': ',
+  en: ': ',
+  de: ': ',
+  fr: ' : ',
+};
+
 const SITEMAP_NAME = 'sitemap-comuni-fiscale.xml';
 const FISCAL_YEAR_LABEL = '2024';
 
@@ -598,15 +615,23 @@ export function renderAboveFloorPage(params: {
   });
 
   // Budget-aware cascade — sibling of the same fix in employerProfilePagesPlugin.ts
-  // / professionCityLandings.ts / professionCantonLandings.ts (audit:title-length
-  // regression #4593): `c.title(n)` has no fallback, so a comune name longer than
-  // today's corridor dataset's longest (19 chars, "Casnate con Bernate", already
-  // 62/66 for IT) would overflow with no recovery. Not currently overflowing
-  // (verified against the live dataset) but the SAME unguarded single-candidate
-  // shape as the pages that DID regress — fixed defensively while already
-  // touching this file, per CLAUDE.md non-negotiable #6. Never truncates the
-  // comune name itself (composePlaceTitle policy) — falls back to the bare name.
-  const titleCandidates = [c.title(n), n];
+  // / professionCityLandings.ts / professionCantonLandings.ts / the FR border
+  // municipality plugin (audit:title-length regression #4593, issue #4886):
+  // `c.title(n)` has no fallback, so a comune name longer than today's corridor
+  // dataset's longest (19 chars, "Casnate con Bernate", already 62/66 for IT)
+  // would overflow with no recovery. Not currently overflowing (verified
+  // against the live dataset). Three rungs, longest-first: `c.title(n)` (full
+  // sentence) -> keyword-tail (still names the topic) -> role label
+  // (shortest, still keyword-bearing). The bare comune name is NEVER a
+  // candidate (issue #4886): it stays under the char cap but carries zero
+  // query-intent signal, so falling back to it is SEO-dead, not a safe
+  // degradation — never truncates the comune name itself either
+  // (composePlaceTitle policy).
+  const titleCandidates = [
+    c.title(n),
+    `${n}${TITLE_COLON[locale]}${TITLE_KEYWORD_TAIL[locale]}`,
+    `${n}${TITLE_COLON[locale]}${c.role}`,
+  ];
   const html = buildSeoPageHtml({
     locale,
     title: composePlaceTitle(titleCandidates, TITLE_MAX_CHARS, (s) => esc(s).length),

--- a/build-plugins/frenchBorderMunicipalityPagesPlugin.ts
+++ b/build-plugins/frenchBorderMunicipalityPagesPlugin.ts
@@ -109,6 +109,18 @@ interface Copy {
   hubLabel: string;
   h1: (name: string, regime: string) => string;
   title: (name: string) => string;
+  /**
+   * Second cascade rung for <title> (composePlaceTitle) — shorter than
+   * `title` but still keyword-bearing (issue #4886: a bare-name last
+   * candidate is CTR-dead, no query-intent signal).
+   */
+  titleMid: (name: string) => string;
+  /**
+   * Shortest cascade rung for <title> — never the bare commune name.
+   * Reuses this locale's core "living in X" phrase so even the minimal
+   * form still carries the page's local-SEO keyword.
+   */
+  titleShort: (name: string) => string;
   desc: (name: string, regime: string) => string;
   lede: (name: string, regime: string, tax: string) => string;
   tilePop: string;
@@ -147,6 +159,8 @@ const COPY: Record<FrenchLocale, Copy> = {
     hubLabel: 'Vivere in Francia e lavorare in Svizzera',
     h1: (n, r) => `Vivere a ${n} e lavorare in Svizzera: regime ${r}`,
     title: (n) => `Vivere a ${n} e lavorare in Svizzera`,
+    titleMid: (n) => `${n}: Guida frontalieri`,
+    titleShort: (n) => `Vivere a ${n}`,
     desc: (n, r) => `Affitti, distanza dal valico e tassazione per chi vive a ${n} e lavora in Svizzera. Regime ${r}.`,
     lede: (n, r, t) =>
       `${n} rientra nel regime ${r}: per un profilo tipo frontaliere significa circa ${t} di imposta annua sul reddito svizzero.`,
@@ -191,6 +205,8 @@ const COPY: Record<FrenchLocale, Copy> = {
     hubLabel: 'Living in France, working in Switzerland',
     h1: (n, r) => `Living in ${n} and working in Switzerland: ${r} regime`,
     title: (n) => `Living in ${n}, working in Switzerland`,
+    titleMid: (n) => `${n}: Cross-border guide`,
+    titleShort: (n) => `Living in ${n}`,
     desc: (n, r) => `Rent, distance to the border crossing and taxation for residents of ${n} working in Switzerland. ${r} regime.`,
     lede: (n, r, t) =>
       `${n} falls under the ${r} regime: for a typical cross-border profile that means about ${t} of annual tax on Swiss income.`,
@@ -235,6 +251,8 @@ const COPY: Record<FrenchLocale, Copy> = {
     hubLabel: 'In Frankreich leben, in der Schweiz arbeiten',
     h1: (n, r) => `Leben in ${n} und Arbeiten in der Schweiz: Regime ${r}`,
     title: (n) => `Leben in ${n}, Arbeiten in der Schweiz`,
+    titleMid: (n) => `${n}: Grenzgänger-Ratgeber`,
+    titleShort: (n) => `Leben in ${n}`,
     desc: (n, r) => `Miete, Distanz zum Grenzübergang und Besteuerung für Einwohner von ${n}, die in der Schweiz arbeiten. Regime ${r}.`,
     lede: (n, r, t) =>
       `${n} fällt unter das Regime ${r}: für ein typisches Grenzgänger-Profil bedeutet das rund ${t} Jahressteuer auf das Schweizer Einkommen.`,
@@ -279,6 +297,8 @@ const COPY: Record<FrenchLocale, Copy> = {
     hubLabel: 'Vivre en France, travailler en Suisse',
     h1: (n, r) => `Vivre à ${n} et travailler en Suisse : régime ${r}`,
     title: (n) => `Vivre à ${n}, travailler en Suisse`,
+    titleMid: (n) => `${n} : Guide frontalier`,
+    titleShort: (n) => `Vivre à ${n}`,
     desc: (n, r) => `Loyers, distance à la frontière et fiscalité pour les habitants de ${n} qui travaillent en Suisse. Régime ${r}.`,
     lede: (n, r, t) =>
       `${n} relève du régime ${r} : pour un profil frontalier type, cela représente environ ${t} d'impôt annuel sur le revenu suisse.`,
@@ -454,13 +474,18 @@ export function renderAboveFloorPage(params: {
     ],
   });
 
-  // Budget-aware cascade — same fix applied across the SSG family
-  // (audit:title-length regression #4593): `c.title(n)` has no fallback, so a
-  // commune name longer than today's dataset's longest (24 chars,
-  // "Saint-Julien-en-Genevois") would overflow with no recovery. Not
-  // currently overflowing (verified against the live dataset) but the SAME
-  // unguarded single-candidate shape as the pages that DID regress.
-  const titleCandidates = [c.title(n), n];
+  // Budget-aware, keyword-preserving cascade (composePlaceTitle) — three
+  // rungs, longest-first (issue #4886): `title` (full sentence) →
+  // `titleMid` (name + role, e.g. "{name}: Guida frontalieri") → `titleShort`
+  // (the shortest form that still carries this locale's core "living in
+  // {name}" keyword). The bare commune name is NEVER a candidate: it stays
+  // under the char cap but carries zero query-intent signal, so it would be
+  // SEO-dead if ever selected. `title` alone (34 fixed chars) already fits
+  // every commune in today's dataset (longest name: 24 chars,
+  // "Saint-Julien-en-Genevois") — the extra rungs only matter for
+  // hypothetical future entries with much longer names, same regression
+  // class as audit:title-length #4593.
+  const titleCandidates = [c.title(n), c.titleMid(n), c.titleShort(n)];
   const html = buildSeoPageHtml({
     locale,
     title: composePlaceTitle(titleCandidates, TITLE_MAX_CHARS, (s) => esc(s).length),

--- a/data/borderCrossings.ts
+++ b/data/borderCrossings.ts
@@ -2513,21 +2513,11 @@ export const borderCrossings: BorderCrossing[] = [
 // yet, and as a sane baseline before the first compute run lands in
 // `data/`.
 import computedAverages from './border-wait-averages.json' with { type: 'json' };
-
-function slugifyName(name: string): string {
- return name
- .normalize('NFKD')
- .replace(/[̀-ͯ]/g, '')
- .replace(/\([^)]*\)/g, '')
- .replace(/[^a-zA-Z0-9]+/g, '-')
- .replace(/-+/g, '-')
- .replace(/^-|-$/g, '')
- .toLowerCase();
-}
+import { slugifyCrossingName } from '../services/borderCrossingSlug';
 
 const computed = computedAverages as Record<string, { morning?: string; evening?: string }>;
 for (const c of borderCrossings) {
- const slug = slugifyName(c.name);
+ const slug = slugifyCrossingName(c.name);
  const entry = computed[slug];
  if (!entry) continue;
  if (entry.morning) c.avgWaitMorning = entry.morning;

--- a/functions/src/borderCrossingsData.js
+++ b/functions/src/borderCrossingsData.js
@@ -6,13 +6,40 @@
  */
 
 /**
+ * Explicit per-name overrides for crossings whose display name collides with
+ * another crossing's slug under the general rule below (issue #4890): the
+ * general rule strips parenthetical content, and 'Widnau-Lustenau
+ * (Wiesenrain)' / 'Widnau-Lustenau (Schmitterbrücke)' both reduce to
+ * "widnau-lustenau". 'Wiesenrain' keeps the unchanged slug (it is the first
+ * of the two in this file / data/borderCrossings.ts); 'Schmitterbrücke' gets
+ * this override instead. Neither crossing has a public /traffico-dogane/
+ * page, so no redirect is needed — do NOT change the general rule itself, 5
+ * other crossings (incl. the primary Chiasso Centro one) have indexed URLs
+ * that depend on parens being stripped.
+ *
+ * Mirror of the override in services/borderCrossingSlug.ts — keep both in
+ * sync by hand (see file header). Anti-collision regression coverage lives
+ * in tests/border-crossing-slug-collision.test.ts.
+ *
+ * @type {Record<string, string>}
+ */
+const CROSSING_SLUG_OVERRIDES = {
+ 'Widnau-Lustenau (Schmitterbrücke)': 'widnau-lustenau-schmitterbrucke',
+};
+
+/**
  * Converts a crossing name to a URL-safe slug.
- * Must stay in sync with slugifyCrossingName() in TrafficAlerts.tsx.
+ * Must stay in sync with slugifyCrossingName() in services/borderCrossingSlug.ts
+ * (the app-layer copy — cannot share a module across the bundler boundary).
  *
  * @param {string} name
  * @returns {string}
  */
 export function slugifyCrossingName(name) {
+ const override = CROSSING_SLUG_OVERRIDES[name];
+ if (override) {
+ return override;
+ }
  return name
  .normalize('NFKD')
  .replace(/[\u0300-\u036f]/g, '')

--- a/scripts/fetch-webcam-snapshots-for-og.mjs
+++ b/scripts/fetch-webcam-snapshots-for-og.mjs
@@ -36,6 +36,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import sharp from 'sharp';
 import { buildCookieHeader, updateCookieJar } from './lib/tiChCookieJar.mjs';
+import { slugifyCrossingName as slugifyName } from '../services/borderCrossingSlug.ts';
 
 // ── Config ────────────────────────────────────────────────────
 const DEFAULT_OUT_SUBDIR = path.join('og', 'border-wait');
@@ -60,18 +61,6 @@ const MAX_BYTES = 200 * 1024; // 200 KB per file
 // (scripts/lib/tiChCookieJar.mjs) re-uses cookies across feeds, exactly as
 // `analyze-webcam-frame.mjs` does for the runtime traffic-monitor fetcher
 // (commit d8d71dbd1e).
-
-// Mirror of borderWaitPagesPlugin.ts#slugifyName — MUST stay in sync.
-function slugifyName(name) {
-  return name
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/\([^)]*\)/g, '')
-    .replace(/[^a-zA-Z0-9]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-    .toLowerCase();
-}
 
 /**
  * Fetch a URL with a User-Agent header and a timeout. Returns a Buffer or

--- a/services/borderCrossingSlug.ts
+++ b/services/borderCrossingSlug.ts
@@ -1,4 +1,25 @@
 /**
+ * Explicit per-name overrides for crossings whose display name collides with
+ * another crossing's slug under the general rule below (issue #4890): the
+ * general rule strips parenthetical content, and 'Widnau-Lustenau
+ * (Wiesenrain)' / 'Widnau-Lustenau (Schmitterbrücke)' both reduce to
+ * "widnau-lustenau". 'Wiesenrain' keeps the unchanged slug (it is the first
+ * of the two in data/borderCrossings.ts); 'Schmitterbrücke' gets this
+ * override instead. Neither crossing has a public /traffico-dogane/ page, so
+ * no redirect is needed — do NOT change the general rule itself, 5 other
+ * crossings (incl. the primary Chiasso Centro one) have indexed URLs that
+ * depend on parens being stripped.
+ *
+ * Anti-collision regression coverage lives in
+ * tests/border-crossing-slug-collision.test.ts — add a new override here
+ * (never edit the general rule) and it enforces every slug, including the
+ * new one, stays unique dataset-wide.
+ */
+const CROSSING_SLUG_OVERRIDES: Readonly<Record<string, string>> = {
+  'Widnau-Lustenau (Schmitterbrücke)': 'widnau-lustenau-schmitterbrucke',
+};
+
+/**
  * Canonical slug for a border crossing's display name.
  *
  * Single source of truth for the app layer (services + components) so the
@@ -11,6 +32,10 @@
  * boundary, so they are kept byte-equivalent by hand.
  */
 export function slugifyCrossingName(name: string): string {
+  const override = CROSSING_SLUG_OVERRIDES[name];
+  if (override) {
+    return override;
+  }
   return name
     .normalize('NFKD')
     .replace(/[̀-ͯ]/g, '')

--- a/tests/border-crossing-slug-collision.test.ts
+++ b/tests/border-crossing-slug-collision.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression coverage for issue #4890: two border crossings —
+ * 'Widnau-Lustenau (Wiesenrain)' and 'Widnau-Lustenau (Schmitterbrücke)' —
+ * both collapsed to the same slug ("widnau-lustenau") because the general
+ * slugify rule in services/borderCrossingSlug.ts strips parenthetical
+ * content. Every slug-keyed structure (data/border-wait-current.json,
+ * data/border-wait-averages.json, data/border-wait-history/*.json, runtime
+ * maps) silently let one crossing's data overwrite the other's.
+ *
+ * The fix is an explicit per-name override in slugifyCrossingName(), not a
+ * change to the general rule — 5 crossings (incl. the primary Chiasso Centro
+ * one) have live, indexed /traffico-dogane/{slug}/oggi/ pages whose URL
+ * depends on parens being stripped by the general rule.
+ *
+ * This test:
+ *  1. Re-derives the expected slug for every crossing in the dataset from an
+ *     independent copy of the *general* rule (not by importing/calling
+ *     slugifyCrossingName for the "expected" side), so a future accidental
+ *     change to the general regex is caught here too, not only by the
+ *     function testing itself. The one known override is applied on top.
+ *  2. Explicitly pins the 5 public, indexed slugs so they can never move.
+ *  3. Asserts the full dataset produces zero duplicate slugs.
+ *  4. Proves the duplicate-detection mechanism itself actually catches a
+ *     collision, using a synthetic crossing name engineered to collide the
+ *     same way the original bug happened — this is what stops the defect
+ *     class from recurring when new crossings are added.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { borderCrossings } from '../data/borderCrossings';
+import { slugifyCrossingName } from '../services/borderCrossingSlug';
+
+// Independent re-implementation of the *general* slugify rule only (no
+// override lookup) — deliberately not imported from services/borderCrossingSlug.ts,
+// so this test doesn't just check the production function against itself.
+function generalSlugify(name: string): string {
+  return name
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/\([^)]*\)/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase();
+}
+
+// The one known, intentional exception: production overrides this exact name
+// so it no longer collides with 'Widnau-Lustenau (Wiesenrain)', which keeps
+// the slug the general rule would produce unchanged.
+const KNOWN_OVERRIDES: Readonly<Record<string, string>> = {
+  'Widnau-Lustenau (Schmitterbrücke)': 'widnau-lustenau-schmitterbrucke',
+};
+
+// The 5 crossings with a live, indexed /traffico-dogane/{slug}/oggi/ page
+// (see build-plugins/borderWaitData.ts#BORDER_WAIT_CROSSINGS) — their slug
+// must never move, or the already-indexed URL breaks.
+const PUBLIC_SLUGS: Readonly<Record<string, string>> = {
+  'Chiasso Centro (Ponte Chiasso)': 'chiasso-centro',
+  'Gaggiolo (Cantello-Stabio)': 'gaggiolo',
+  'San Pietro (Clivio-Stabio)': 'san-pietro',
+  'Piaggio Valmara (Cannobio-Brissago)': 'piaggio-valmara',
+  'Camedo (Re-Centovalli)': 'camedo',
+};
+
+/** Returns every slug that appears more than once in `names`. */
+function findDuplicateSlugs(names: readonly string[]): string[] {
+  const slugs = names.map(slugifyCrossingName);
+  const seen = new Set<string>();
+  const dupes: string[] = [];
+  for (const s of slugs) {
+    if (seen.has(s)) dupes.push(s);
+    seen.add(s);
+  }
+  return dupes;
+}
+
+describe('slugifyCrossingName — issue #4890 collision fix', () => {
+  it('produces the expected slug for every crossing in the dataset', () => {
+    expect(borderCrossings.length).toBeGreaterThan(0);
+    for (const c of borderCrossings) {
+      const expected = KNOWN_OVERRIDES[c.name] ?? generalSlugify(c.name);
+      expect(slugifyCrossingName(c.name), `slug for "${c.name}"`).toBe(expected);
+    }
+  });
+
+  it('keeps the 5 public /traffico-dogane/{slug}/oggi/ URLs unchanged', () => {
+    for (const [name, expectedSlug] of Object.entries(PUBLIC_SLUGS)) {
+      // Sanity: these names must still exist verbatim in the dataset, else
+      // the assertion below would silently test a name nobody ships.
+      expect(
+        borderCrossings.some(c => c.name === name),
+        `"${name}" is expected to exist in data/borderCrossings.ts`
+      ).toBe(true);
+      expect(slugifyCrossingName(name), `public slug for "${name}"`).toBe(expectedSlug);
+    }
+  });
+
+  it('has no duplicate slugs across the full dataset', () => {
+    const dupes = findDuplicateSlugs(borderCrossings.map(c => c.name));
+    expect(dupes, `duplicate slug(s): ${dupes.join(', ')}`).toEqual([]);
+  });
+
+  it('the Widnau-Lustenau pair no longer collides', () => {
+    const wiesenrain = slugifyCrossingName('Widnau-Lustenau (Wiesenrain)');
+    const schmitterbruecke = slugifyCrossingName('Widnau-Lustenau (Schmitterbrücke)');
+    expect(wiesenrain).toBe('widnau-lustenau');
+    expect(schmitterbruecke).toBe('widnau-lustenau-schmitterbrucke');
+    expect(wiesenrain).not.toBe(schmitterbruecke);
+  });
+
+  it('detects a collision if a fictitious crossing is introduced (defect-class regression guard)', () => {
+    // Engineered the same way the original bug happened: a parenthetical
+    // suffix that the general rule strips, landing on an already-used slug.
+    const fictitiousCollidingName = 'Chiasso Centro (Nuovo Ingresso Fittizio)';
+    expect(slugifyCrossingName(fictitiousCollidingName)).toBe('chiasso-centro');
+
+    const namesWithIntruder = [...borderCrossings.map(c => c.name), fictitiousCollidingName];
+    const dupes = findDuplicateSlugs(namesWithIntruder);
+    expect(dupes).toContain('chiasso-centro');
+
+    // Control: without the intruder, the same detector reports zero dupes —
+    // proves the failure above comes from the intruder, not a broken detector.
+    expect(findDuplicateSlugs(borderCrossings.map(c => c.name))).toEqual([]);
+  });
+});

--- a/tests/french-border-municipality-pages.test.ts
+++ b/tests/french-border-municipality-pages.test.ts
@@ -18,7 +18,11 @@
 import { describe, it, expect } from 'vitest';
 
 import { renderAboveFloorPage } from '@/build-plugins/frenchBorderMunicipalityPagesPlugin';
-import { FRENCH_ABOVE_FLOOR, type FrenchBorderMunicipality } from '@/build-plugins/frenchBorderMunicipalityData';
+import {
+  FRENCH_ABOVE_FLOOR,
+  FRENCH_LOCALES,
+  type FrenchBorderMunicipality,
+} from '@/build-plugins/frenchBorderMunicipalityData';
 import { TITLE_MAX_CHARS } from '@/build-plugins/shared/titleSuffix';
 import {
   assertPlausibleMunicipality,
@@ -48,6 +52,78 @@ describe('French border municipality title cascade holds for an implausibly long
     expect(titleMatch).not.toBeNull();
     expect(titleMatch![1].length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
   });
+});
+
+/**
+ * The cap-only assertion above cannot fail: `composePlaceTitle` already
+ * truncates the shortest candidate as a last resort, so the 66-char budget
+ * always holds. The defect it was meant to catch is different — with a
+ * 2-rung cascade `[c.title(n), n]`, a name that pushes the rich candidate
+ * over budget degrades to the BARE COMMUNE NAME, which fits the cap but
+ * carries no query intent at all (`<title>Hohentengen am Hochrhein</title>`).
+ *
+ * These tests assert the property that actually matters: every emitted title
+ * keeps a keyword, in every locale, and never falls back to the naked name.
+ * Length is measured AFTER HTML escaping, because that is the string that
+ * ships and the string `audit:title-length` reads.
+ */
+describe('title cascade never degrades to a keyword-free bare name (#4886 Item 1)', () => {
+  const escapeHtml = (value: string): string =>
+    value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+
+  const dateStamp = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  for (const municipality of FRENCH_ABOVE_FLOOR) {
+    for (const locale of FRENCH_LOCALES) {
+      it(`${municipality.name} [${locale}] keeps a keyword and fits the escaped cap`, () => {
+        const { html } = renderAboveFloorPage({ municipality, locale, dateStamp, distDir: DIST });
+        const match = html.match(/<title>([^<]*)<\/title>/);
+        expect(match).not.toBeNull();
+
+        const title = match![1];
+        expect(title.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+
+        // Never the naked commune name — that is the SEO-dead fallback.
+        expect(title).not.toBe(escapeHtml(municipality.name));
+
+        // Never a mid-headline ellipsis: the SERP policy in titleSuffix.ts
+        // forbids it (CTR fell 4.8% -> 0.99% when it last shipped).
+        expect(title).not.toContain('…');
+
+        // The commune name must survive: it is the local-SEO token.
+        expect(title).toContain(escapeHtml(municipality.name));
+      });
+    }
+  }
+});
+
+/**
+ * A name long enough to blow every rung must still degrade gracefully: the
+ * shortest rung is keyword-bearing by construction, so even the truncated
+ * result keeps the page's intent rather than collapsing to a naked toponym.
+ */
+describe('longest-rung fallback stays keyword-bearing (#4886 Item 1)', () => {
+  const dateStamp = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const overlongName = 'Saint-Jean-de-la-Vallee-du-Mont-Blanc-sur-Genevois-les-Deux-Rives';
+
+  for (const locale of FRENCH_LOCALES) {
+    it(`[${locale}] does not emit the bare overlong name as the whole title`, () => {
+      const municipality: FrenchBorderMunicipality = {
+        ...FRENCH_ABOVE_FLOOR[0],
+        name: overlongName,
+      };
+      const { html } = renderAboveFloorPage({ municipality, locale, dateStamp, distDir: DIST });
+      const title = html.match(/<title>([^<]*)<\/title>/)![1];
+
+      expect(title.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+      expect(title).not.toBe(overlongName);
+      expect(title.trim()).not.toBe('');
+    });
+  }
 });
 
 describe('municipality plausibility guard (#4886)', () => {

--- a/tests/regression/border-wait-hub-links.test.tsx
+++ b/tests/regression/border-wait-hub-links.test.tsx
@@ -13,19 +13,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { borderCrossings } from '../../data/borderCrossings';
-
-// Mirror of FrontierGuide.tsx#slugifyCrossingName — kept in sync manually.
-// If this test breaks, update the component function to match.
-function slugifyCrossingName(name: string): string {
-  return name
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/\([^)]*\)/g, '')
-    .replace(/[^a-zA-Z0-9]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-    .toLowerCase();
-}
+import { slugifyCrossingName } from '../../services/borderCrossingSlug';
 
 function buildDetailHref(slug: string): string {
   return `/traffico-dogane/${slug}/oggi/`;


### PR DESCRIPTION
## Implementato

Due difetti reali dell'area border-crossings, trovati studiando il backlog e verificati sul codice prima di scrivere una riga.

### 1. Cascata dei titoli che degradava a un titolo senza keyword (#4886 Item 1)

La PR #4891, mergiata mentre questo lavoro era in corso, ha coperto l'Item 2 (guardia di plausibilità) e ha aggiunto un test di regressione sul titolo, ma **ha lasciato aperto l'Item 1**: nessuno dei due plugin è stato toccato.

L'azione descritta nell'issue («aggiungere un terzo livello di fallback con troncamento») era peraltro sbagliata su due punti verificati:

- `composePlaceTitle` **tronca già** il candidato più corto come ultima istanza, quindi il cap di 66 caratteri non poteva essere sforato. Il test aggiunto da #4891 asserisce esattamente questo, ed è un test che passava anche prima;
- il troncamento mid-headline con `…` è **vietato dalla policy** documentata in `build-plugins/shared/titleSuffix.ts`, che cita la regressione di CTR da 4,8% a 0,99% su `/calcola-stipendio/`.

Il difetto reale è che la cascata aveva due soli gradini, `[titoloRicco(nome), nome]`: quando il primo eccede il budget si degrada al **nome nudo del comune**, che sta nel cap ma non porta alcuna intenzione di ricerca. Verificato direttamente contro `composePlaceTitle`:

```
cascata a 2 gradini -> "Saint-Jean-de-la-Vallee-du-Mont-Blanc-sur-Genevois-les-Deux-Rives"
cascata a 3 gradini -> "Vivere a Saint-Jean-de-la-Vallee-du-Mont-Blanc-sur-Genevois-les-D…"
```

Entrambi i plugin usano ora una cascata a tre gradini a degradazione graduale, il cui gradino più corto resta keyword-bearing (`Vivere a X` / `Living in X` / `Leben in X` / `Vivre à X`), replicando il pattern già consolidato in `eventsSeoPagesPlugin.ts`. Il testo di ogni locale riusa la formulazione già presente in quel locale, senza traduzioni inventate.

`build-plugins/fiscalMunicipalityPagesPlugin.ts` è stato modificato in modo deliberatamente chirurgico — solo le righe della cascata più due mappe di costanti additive — perché un'altra sessione ha lavoro non committato sui file adiacenti di quella famiglia (`fiscalMunicipalityData.ts`, `scripts/build-fiscal-municipalities.mjs`, `data/municipalities.ts`, `data/fiscal-municipalities.json`), **nessuno dei quali è toccato qui**.

### 2. Collisione di slug fra due valichi (#4890)

`Widnau-Lustenau (Wiesenrain)` e `Widnau-Lustenau (Schmitterbrücke)` collassavano entrambi su `widnau-lustenau` — unica collisione su 143 valichi. In ogni struttura indicizzata per slug uno dei due sovrascriveva silenziosamente l'altro.

**La correzione ovvia sarebbe stata distruttiva.** La rimozione delle parentesi non è un difetto: è ciò che produce gli slug puliti in produzione. Cambiare la regola generale avrebbe rinominato **20 URL indicizzate** (5 valichi × 4 locali), incluso `/traffico-dogane/chiasso-centro/oggi/`, il valico principale del sito. Verificato prima di intervenire.

La regola generale è quindi rimasta **intatta**, e la disambiguazione avviene tramite un override esplicito consultato prima di essa. `Wiesenrain` conserva lo slug attuale (compare per primo nel dataset, quindi è quello già presente nei dati storici); `Schmitterbrücke` riceve `widnau-lustenau-schmitterbrucke`. Nessuno dei due ha una pagina pubblica, quindi non servono redirect — verificato in modo indipendente contro `BORDER_WAIT_CROSSINGS` e `ALL_BORDER_CROSSING_IDS`.

**Eliminata la duplicazione che aveva reso possibile il difetto.** La stessa regex era copiata a mano in 5 punti, tenuti allineati «by hand» per commento esplicito nel codice. Ora ogni chiamante importa l'unica implementazione in `services/borderCrossingSlug.ts`:

- `build-plugins/borderWaitPagesPlugin.ts`
- `data/borderCrossings.ts`
- `scripts/fetch-webcam-snapshots-for-og.mjs`
- `tests/regression/border-wait-hub-links.test.tsx`
- `functions/src/borderCrossingsData.js` resta un gemello byte-equivalente perché vive oltre il confine del bundler e non può importare il modulo — vincolo già documentato nel file.

In `scripts/fetch-webcam-snapshots-for-og.mjs` l'import richiede l'estensione `.ts` esplicita: è caricato da Node ESM puro a build time, che non fa risoluzione in stile bundler. La suite vitest passava **anche senza** l'estensione; il difetto è emerso solo riproducendo con `node` diretto (`ERR_MODULE_NOT_FOUND`). È il caso in cui un verde CI avrebbe mascherato una rottura reale.

Corretti anche due commenti in `build-plugins/borderWaitData.ts` che indicavano `data/borderCrossings.ts` come sorgente della funzione, che ora la importa soltanto (disciplina sul rename, AGENTS.md #6), e un commento stale in `functions/src/borderCrossingsData.js` che rimandava a una copia non più esistente in `TrafficAlerts.tsx`.

### Test

- `tests/french-border-municipality-pages.test.ts` esteso a **90 test**: per ogni comune above-floor e ogni locale verifica che il titolo stia nel cap **misurato dopo l'escaping HTML**, contenga il nome del comune, non coincida col nome nudo e non contenga `…`; più un caso con nome volutamente lunghissimo che prova la degradazione graduale del gradino più corto.
- `tests/border-crossing-slug-collision.test.ts` (nuovo, 5 test): lo slug di ogni valico resta invariato, i 5 slug pubblici sono asseriti nominalmente, l'insieme non contiene duplicati e un valico fittizio in collisione fa fallire il test — è la protezione che impedisce il ripetersi del difetto quando si aggiungeranno valichi (#4889).

Esito reale, eseguito su questo branch:

```
tests/french-border-municipality-pages.test.ts    90 passed
tests/fiscal-municipality-pages.test.ts           10 passed
tests/border-crossing-slug-collision.test.ts       5 passed
tests/border-crossings-data-integrity.test.ts      6 passed
tests/border-wait-pages.test.ts                   30 passed
tests/border-wait-ranking.test.ts                 11 passed
tests/border-wait-og-webcam.test.ts               21 passed
tests/regression/border-wait-hub-links.test.tsx   16 passed
tests/trafficScheduler.test.ts                    13 passed
tests/trafficScheduler.webcam-only.test.ts        16 passed
tests/job-location-snapshot.test.ts                4 passed
tests/search-console-compat.test.ts               30 passed
tests/border-wait-hydration.test.ts + health      36 passed
```

Nessun rosso, nessuna asserzione allentata.

### Sibling-pattern check (AGENTS.md #6)

`check-sibling-patterns.mjs --strict` surfaccia **50 file**. Ognuno è stato sottoposto a un controllo oggettivo per entrambe le classi di difetto di questa PR, non a una valutazione a occhio:

1. *definisce una propria slugify applicata a nomi di valichi?* → **nessuno**. 13 file hanno una slugify propria, tutte di dominio diverso e identificabile dal nome della funzione stessa: `slugifyPath` (`components/guide/FrontierGuide.tsx`, che per i valichi importa invece `slugifyCrossingName`), `slugifyCompanyName` (`build-plugins/companyHubBridgePlugin.ts`, `components/community/JobExpiredView.tsx`), `slugifyLocationName` e `slugifySearchTerm` (`JobExpiredView.tsx`), `slugify`/`slugifyCompanyBuild` (`build-plugins/jobsSeoPagesPlugin.ts`), più `scripts/build-employer-insights.mjs` (nomi di aziende), `scripts/create-article.mjs`, `scripts/publish-journalist-article.mjs`, `services/journalistArticleService.ts` (slug di articoli), `scripts/crawl-insurer-logos.mjs` (loghi), `scripts/update-sbb-jobs.mjs` e `scripts/update-abb-jobs.mjs` (annunci), `components/community/JobBridgeView.tsx` e `JobOrphanView.tsx` (job).

2. *ha una cascata di titoli che termina con la variabile nuda del luogo?* → **nessuno**. Gli 8 call-site di `composePlaceTitle` rimanenti hanno tutti l'ultimo gradino keyword-bearing, verificato uno per uno: `BRIDGE_COPY[locale].title(role, cantonName)` in `professionCantonLandings.ts` e `salaryProfessionCantonPages.ts`, `BRIDGE_COPY[locale].title(role, cityDisplay)` in `professionCityLandings.ts`, prefisso+suffisso in `employerProfilePagesPlugin.ts`, `h1 + anno` in `salaryStatsChCantonPages.ts`, più `eventsSeoPagesPlugin.ts` (il pattern di riferimento), `companyHubBridgePlugin.ts` e `locationHubBridgePlugin.ts`.

3. *consuma `slugifyCrossingName`?* → 8 file lo **importano** dal modulo condiviso senza duplicarlo (`components/guide/TrafficAlerts.tsx`, `components/guide/FrontierGuide.tsx`, `functions/src/trafficSchedulerCore.js`, `services/jobLocationSnapshot.ts`, `services/trafficService.ts`), e 3 lo citano **solo nei commenti** (`services/router.ts`, `build-plugins/borderWaitData.ts`, `build-plugins/borderWaitHydrationScript.ts`) — due di questi contenevano un riferimento diventato stale, corretto in questa PR.

I restanti file condividono con il diff soltanto frammenti generici di slugify (`.replace(/-+/g, '-')`, `.replace(/^-|-$/g, '')`) applicati ad articoli, job, aziende e path GSC: verificato che nessuno importa `borderCrossings` né rimuove le parentesi, quindi non appartengono alla classe.

Push con `--no-verify` per l'eccezione documentata: ogni candidato è stato valutato individualmente con il criterio sopra, non liquidato in blocco.

## Non implementato (ancora)

- **#4882 Germania, #4883 Austria, #4884 Liechtenstein** — *blocked, causa esterna reale*: nessuna delle tre è implementabile senza le rispettive cifre del regime fiscale verificate su fonte ufficiale primaria. Non è un rinvio di comodo: pubblicare un numero fiscale non verificato su pagine indicizzate rivolte a lavoratori reali è il solo errore irreversibile di questo dominio. La ricerca è stata avviata e non ha ancora prodotto fonti utilizzabili. Le tre issue sono state aggiornate con il metodo corretto di derivazione dei comuni, i prerequisiti bloccanti e — per #4883 — la diagnosi del fallimento del tentativo automatico.
- **#4885 Italia Grigioni/Vallese** — *dipendenza dichiarata*: tocca `scripts/build-fiscal-municipalities.mjs` e `data/municipalities.ts`, in modifica non committata da un'altra sessione per #4544. Va eseguita dopo quel merge. L'issue è stata aggiornata con il conteggio reale (8 pagine above-floor col floor attuale) e la dipendenza.
- **#4889 superficie pubblica dei 116 valichi** — *aperta, tracciata*: è il gap di maggior valore dell'area (dati già raccolti, zero pagine) ma richiede di generalizzare i registry e le regioni oltre il Ticino, con un volume di ~464 pagine da valutare contro il budget di memoria della build. Questa PR ne rimuove il prerequisito bloccante (la collisione di slug).
- **#4892 popup della mappa** e **#4893 198 comuni italiani** — *aperte, tracciate*: entrambe insistono sulla pagina con la regressione INP #4676 e vanno misurate prima/dopo, non stimate.
- Il test aggiunto da #4891 usa una data assoluta (`'2026-07-28'`) nella fixture, contro la regola del progetto sulle date relative. Non corretto qui per non toccare inutilmente un file appena mergiato da un'altra PR; segnalato perché è una bomba a orologeria di calendario.
- L'indice GitNexus è antecedente a PR #4878 e non conosce i simboli del template francese. Non rigenerato: è un reindex con effetti sull'intero repo, e altre sessioni stanno modificando file sovrapposti in questo momento.

Refs #4886, #4890, #4545
