### PR TITLE
test(border): guard the slug override table against bundler-boundary drift (#4898 review)

### DIFF
--- a/services/router.ts
+++ b/services/router.ts
@@ -225,7 +225,8 @@ export type StatsSubTab = 'overview' | 'livability' | 'jobs-observatory' | 'sala
  * than imported, to avoid a cycle: that file imports from this one).
  *
  * New crossing → add its slug (must equal `slugifyCrossingName(name)` from
- * `data/borderCrossings.ts`) to this array AND to
+ * `services/borderCrossingSlug.ts`, the single implementation every caller
+ * imports) to this array AND to
  * `build-plugins/borderWaitData.ts` (see the "Adding a new crossing"
  * checklist above `BorderCrossingRegion` there for the full list of maps
  * that need an entry too). Missing it here just means the SPA deep-link

--- a/tests/border-crossing-slug-collision.test.ts
+++ b/tests/border-crossing-slug-collision.test.ts
@@ -123,3 +123,68 @@ describe('slugifyCrossingName — issue #4890 collision fix', () => {
     expect(findDuplicateSlugs(borderCrossings.map(c => c.name))).toEqual([]);
   });
 });
+
+/**
+ * The override table exists in two places: services/borderCrossingSlug.ts (app
+ * layer) and functions/src/borderCrossingsData.js (Firebase Functions, which
+ * writes the Firestore/snapshot keys). They cannot share a module — the
+ * Functions bundle lives outside the Vite tree — so they are kept identical by
+ * hand, exactly the fragility that produced #4890 in the first place.
+ *
+ * PR #4898's reviewer flagged this: an override added to only one side would
+ * silently reproduce the collision for that crossing's Firestore-side data,
+ * with no failing test. These cases close that gap by comparing the two
+ * implementations' OUTPUT over the whole dataset, so any divergence — a missing
+ * override, a reworded general rule, a stray character — fails here.
+ */
+describe('slug parity across the Functions bundler boundary (#4898 review)', () => {
+  it('both implementations agree on every crossing in the dataset', async () => {
+    const { slugifyCrossingName: functionsSlugify } = await import(
+      '../functions/src/borderCrossingsData.js'
+    );
+
+    const divergences = borderCrossings
+      .map((crossing) => ({
+        name: crossing.name,
+        app: slugifyCrossingName(crossing.name),
+        functions: functionsSlugify(crossing.name),
+      }))
+      .filter((row) => row.app !== row.functions);
+
+    expect(
+      divergences,
+      divergences.map((d) => `${d.name}: app="${d.app}" functions="${d.functions}"`).join('; '),
+    ).toEqual([]);
+  });
+
+  it('both implementations carry the same override for the disambiguated crossing', async () => {
+    const { slugifyCrossingName: functionsSlugify } = await import(
+      '../functions/src/borderCrossingsData.js'
+    );
+
+    // If either side loses the override, this drops back to the colliding slug.
+    expect(functionsSlugify('Widnau-Lustenau (Schmitterbrücke)')).toBe(
+      'widnau-lustenau-schmitterbrucke',
+    );
+    expect(functionsSlugify('Widnau-Lustenau (Schmitterbrücke)')).toBe(
+      slugifyCrossingName('Widnau-Lustenau (Schmitterbrücke)'),
+    );
+  });
+
+  it('agrees on names outside the dataset too, including override-free parentheticals', async () => {
+    const { slugifyCrossingName: functionsSlugify } = await import(
+      '../functions/src/borderCrossingsData.js'
+    );
+
+    // Covers the general rule itself, not just the override branch: accents,
+    // parentheses, punctuation runs and leading/trailing separators.
+    for (const probe of [
+      'Chiasso Centro (Ponte Chiasso)',
+      'Sankt Margrethen — Höchst (Alte Rheinbrücke)',
+      '  Zürich/Rafz -- Lottstetten  ',
+      'Col-des-Roches (Col France)',
+    ]) {
+      expect(functionsSlugify(probe), `probe: ${probe}`).toBe(slugifyCrossingName(probe));
+    }
+  });
+});


### PR DESCRIPTION
## Implementato

Follow-up alla review di PR #4898. Chiude i due punti che quella review ha sollevato, entrambi fondati.

### 1. Commento stale in `services/router.ts` (il 🟡 Nit della review)

Il reviewer ha rilevato un'imprecisione reale nel body di #4898: dichiarava corretti i riferimenti diventati stale, ma il diff toccava solo `build-plugins/borderWaitData.ts`. `services/router.ts:227` continuava a indicare `data/borderCrossings.ts` come sorgente di `slugifyCrossingName`, mentre quel file ora la importa soltanto. Corretto qui.

### 2. La tabella di override poteva divergere in silenzio (adversarial check)

Rilievo più sostanziale, e corretto: `CROSSING_SLUG_OVERRIDES` è duplicata a mano fra `services/borderCrossingSlug.ts` e `functions/src/borderCrossingsData.js`, che non possono condividere un modulo perché il bundle delle Functions vive fuori dall'albero Vite.

PR #4898 ha rimosso esattamente questa fragilità per la regex generale — accorpando cinque copie in un unico modulo — e poi l'ha **reintrodotta per la tabella degli override**. Un override aggiunto a un solo lato riprodurrebbe #4890 per i dati Firestore di quel valico, senza che nulla fallisca.

Il guard confronta l'**output** delle due implementazioni su tutto il dataset, invece di fare il diff delle due tabelle: così falliscono allo stesso modo un override mancante, una riscrittura della regola generale o un carattere di troppo. Le sonde coprono anche la regola generale, non solo il ramo dell'override — accenti, parentesi, sequenze di punteggiatura e spazi ai bordi.

**Verificato discriminante, non decorativo**: rimuovendo l'override dal solo lato Functions, 2 di questi test diventano rossi; ripristinandolo tornano verdi. La prova è stata eseguita, non dedotta.

### Test

```
tests/border-crossing-slug-collision.test.ts   8 passed  (erano 5)
```

I 3 casi nuovi: parità su ogni valico del dataset, parità sull'override disambiguato, parità su nomi fuori dataset con parentetiche e accenti.

### Sibling-pattern check (AGENTS.md #6)

`check-sibling-patterns.mjs --strict` surfaccia **8 file**, tutti per il token condiviso `borderCrossingSlug`. Verificato uno per uno con criterio oggettivo — *definisce una propria `slugifyCrossingName`?*:

- `build-plugins/borderWaitData.ts`, `build-plugins/borderWaitPagesPlugin.ts`, `components/guide/FrontierGuide.tsx`, `components/guide/TrafficAlerts.tsx`, `scripts/fetch-webcam-snapshots-for-og.mjs`, `services/jobLocationSnapshot.ts`, `services/trafficService.ts` → **no**, importano tutti il modulo condiviso. Nessun antipattern.
- `functions/src/borderCrossingsData.js` → **sì**, ed è l'unico: è il gemello oltre il confine del bundler, il cui allineamento è precisamente ciò che questa PR mette sotto test. Non è un difetto da correggere, è il soggetto della PR.

Nessun candidato richiede un fix aggiuntivo: la classe è chiusa da questo guard invece che da altre copie da tenere allineate a mano.

## Non implementato (ancora)

- **Il terzo rilievo dell'adversarial check** — `scripts/fetch-webcam-snapshots-for-og.mjs` importa il modulo condiviso con estensione `.ts` esplicita e viene eseguito come Node ESM puro, affidandosi al type-stripping nativo. Il reviewer ha osservato che non è esercitato dai test. **Non coperto qui**: verificarlo richiede eseguire lo script reale in un ambiente Node senza bundler, cioè un test di integrazione a build time che questa suite non ha. Il rischio resta basso per la ragione già accertata dal reviewer stesso — l'unico call site avvolge l'import dinamico in try/catch con fallback esplicito all'immagine OG di default, quindi un fallimento degrada senza rompere né la build né la pagina. Se in futuro quel fallback venisse rimosso, questo diventa un rischio reale e va coperto.
- Nessun altro residuo: entrambi i punti sollevati dalla review di #4898 sono chiusi in questa PR.

Refs #4890, #4898
