### PR TITLE
fix(email): ri-verifica idoneità welcome dentro la transazione + 2 nit di review

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -560,10 +560,14 @@ export const newsletterSendConfirmation = onRequest(
  },
 );
 
-// Post-signup welcome email, presigned trigger (mirrors newsletterSendConfirmation).
-// The `confirm` action in newsletterSubscriptionManagement.js already fires this
-// within seconds of double opt-in — this endpoint exists for a resend/retry path
-// (e.g. a presigned link) that needs to trigger the same send independently.
+// Post-signup welcome email (mirrors newsletterSendConfirmation).
+// FUNNEL-CRITICAL: this is the ONLY welcome touchpoint for pre-confirmed
+// subscribers — Google One Tap, social sign-in and the job-unlock gates, which
+// together are ~82% of all signups. Those paths never reach double opt-in, so
+// the `confirm` action in newsletterSubscriptionManagement.js (which covers the
+// remaining minority) never fires for them. Called from
+// services/newsletterSubscribers.ts:upsertNewsletterSubscriber. If this endpoint
+// breaks, most new subscribers silently receive no welcome email at all.
 export const newsletterSendWelcome = onRequest(
  {
  region: 'europe-west6',

--- a/functions/src/lib/welcomeEmailTemplate.js
+++ b/functions/src/lib/welcomeEmailTemplate.js
@@ -16,7 +16,7 @@
  *     LOCALE_PATH_MAP (superset of services/newsletter-template.mjs's map +
  *     the publisher-only routes from services/routeSlugs.data.ts, which the
  *     newsletter template never needed). This file keeps its OWN
- *     `directUrl`/`localizedUrl` (trailing-slash behavior, unlike the
+ *     `directUrlSlashed`/`localizedUrlSlashed` (trailing-slash behavior, unlike the
  *     newsletter template's bare-path version) and only imports the map.
  *   - the "Consigliato per te" card → functions/src/lib/recommendedBlock.js,
  *     which reads the live enable gate from
@@ -67,17 +67,17 @@ function ensureTrailingSlash(url) {
   return url.endsWith('/') ? url : `${url}/`;
 }
 
-function directUrl(path) {
+function directUrlSlashed(path) {
   if (/^https?:\/\//i.test(path)) return ensureTrailingSlash(path);
   const full = `${BASE_URL}${path.startsWith('/') ? path : '/' + path}`;
   return ensureTrailingSlash(full);
 }
 
-function localizedUrl(itPath, locale) {
+function localizedUrlSlashed(itPath, locale) {
   const lang = normLocale(locale);
   const variants = LOCALE_PATH_MAP[itPath];
   const path = variants ? (variants[lang] || variants.it) : itPath;
-  return directUrl(path);
+  return directUrlSlashed(path);
 }
 
 // ── Greeting ───────────────────────────────────────────────────────
@@ -352,12 +352,12 @@ function buildJobContent(locale, { company, sectorKey, locationLabel, jobBackPat
   const hook = JOB_HOOK_TEMPLATE[locale](descriptor);
   const quickLinks = [];
   if (jobBackPath) {
-    quickLinks.push({ label: LINKS.backToJob[locale], href: directUrl(jobBackPath) });
+    quickLinks.push({ label: LINKS.backToJob[locale], href: directUrlSlashed(jobBackPath) });
   } else {
-    quickLinks.push({ label: LINKS.allJobs[locale], href: localizedUrl('/cerca-lavoro-svizzera', locale) });
+    quickLinks.push({ label: LINKS.allJobs[locale], href: localizedUrlSlashed('/cerca-lavoro-svizzera', locale) });
   }
-  quickLinks.push({ label: LINKS.calcNet[locale], href: localizedUrl('/calcola-stipendio', locale) });
-  quickLinks.push({ label: LINKS.compareLamal[locale], href: localizedUrl('/compara-servizi/confronta-casse-malati', locale) });
+  quickLinks.push({ label: LINKS.calcNet[locale], href: localizedUrlSlashed('/calcola-stipendio', locale) });
+  quickLinks.push({ label: LINKS.compareLamal[locale], href: localizedUrlSlashed('/compara-servizi/confronta-casse-malati', locale) });
 
   return {
     subject: SUBJECT.job[locale],
@@ -365,7 +365,7 @@ function buildJobContent(locale, { company, sectorKey, locationLabel, jobBackPat
     heading: HEADING.job[locale],
     hook,
     ctaLabel: CTA_LABEL.job[locale],
-    ctaHref: localizedUrl('/cerca-lavoro-svizzera', locale),
+    ctaHref: localizedUrlSlashed('/cerca-lavoro-svizzera', locale),
     quickLinks,
   };
 }
@@ -377,11 +377,11 @@ function buildSalaryContent(locale) {
     heading: HEADING.salary[locale],
     hook: HOOK.salary[locale],
     ctaLabel: CTA_LABEL.salary[locale],
-    ctaHref: localizedUrl('/calcola-stipendio', locale),
+    ctaHref: localizedUrlSlashed('/calcola-stipendio', locale),
     quickLinks: [
-      { label: LINKS.compareLamal[locale], href: localizedUrl('/compara-servizi/confronta-casse-malati', locale) },
-      { label: LINKS.compareFx[locale], href: localizedUrl('/compara-servizi/cambio-franco-euro', locale) },
-      { label: LINKS.searchJobsCh[locale], href: localizedUrl('/cerca-lavoro-svizzera', locale) },
+      { label: LINKS.compareLamal[locale], href: localizedUrlSlashed('/compara-servizi/confronta-casse-malati', locale) },
+      { label: LINKS.compareFx[locale], href: localizedUrlSlashed('/compara-servizi/cambio-franco-euro', locale) },
+      { label: LINKS.searchJobsCh[locale], href: localizedUrlSlashed('/cerca-lavoro-svizzera', locale) },
     ],
   };
 }
@@ -392,8 +392,8 @@ function buildUtilityContent(locale, { toolKey }) {
   // Point at a DIFFERENT tool than the one they just used (lamal → fx
   // comparator; comparator/anything else → the LAMal comparator).
   const ctaHref = toolKey === 'lamal'
-    ? localizedUrl('/compara-servizi/cambio-franco-euro', locale)
-    : localizedUrl('/compara-servizi/confronta-casse-malati', locale);
+    ? localizedUrlSlashed('/compara-servizi/cambio-franco-euro', locale)
+    : localizedUrlSlashed('/compara-servizi/confronta-casse-malati', locale);
 
   return {
     subject: SUBJECT.utility[locale],
@@ -403,9 +403,9 @@ function buildUtilityContent(locale, { toolKey }) {
     ctaLabel: CTA_LABEL.utility[locale],
     ctaHref,
     quickLinks: [
-      { label: LINKS.calcNet[locale], href: localizedUrl('/calcola-stipendio', locale) },
-      { label: LINKS.compareLamal[locale], href: localizedUrl('/compara-servizi/confronta-casse-malati', locale) },
-      { label: LINKS.compareFx[locale], href: localizedUrl('/compara-servizi/cambio-franco-euro', locale) },
+      { label: LINKS.calcNet[locale], href: localizedUrlSlashed('/calcola-stipendio', locale) },
+      { label: LINKS.compareLamal[locale], href: localizedUrlSlashed('/compara-servizi/confronta-casse-malati', locale) },
+      { label: LINKS.compareFx[locale], href: localizedUrlSlashed('/compara-servizi/cambio-franco-euro', locale) },
     ],
   };
 }
@@ -417,11 +417,11 @@ function buildPublisherContent(locale) {
     heading: HEADING.publisher[locale],
     hook: HOOK.publisher[locale],
     ctaLabel: CTA_LABEL.publisher[locale],
-    ctaHref: localizedUrl('/pubblica-offerta', locale),
+    ctaHref: localizedUrlSlashed('/pubblica-offerta', locale),
     quickLinks: [
-      { label: LINKS.howPublishing[locale], href: localizedUrl('/per-le-aziende', locale) },
-      { label: LINKS.publishListing[locale], href: localizedUrl('/pubblica-offerta', locale) },
-      { label: LINKS.myListings[locale], href: localizedUrl('/i-miei-annunci', locale) },
+      { label: LINKS.howPublishing[locale], href: localizedUrlSlashed('/per-le-aziende', locale) },
+      { label: LINKS.publishListing[locale], href: localizedUrlSlashed('/pubblica-offerta', locale) },
+      { label: LINKS.myListings[locale], href: localizedUrlSlashed('/i-miei-annunci', locale) },
     ],
   };
 }
@@ -433,11 +433,11 @@ function buildGeneralContent(locale) {
     heading: HEADING.general[locale],
     hook: HOOK.general[locale],
     ctaLabel: CTA_LABEL.general[locale],
-    ctaHref: localizedUrl('/calcola-stipendio', locale),
+    ctaHref: localizedUrlSlashed('/calcola-stipendio', locale),
     quickLinks: [
-      { label: LINKS.calcNet[locale], href: localizedUrl('/calcola-stipendio', locale) },
-      { label: LINKS.searchJobsCh[locale], href: localizedUrl('/cerca-lavoro-svizzera', locale) },
-      { label: LINKS.compareLamal[locale], href: localizedUrl('/compara-servizi/confronta-casse-malati', locale) },
+      { label: LINKS.calcNet[locale], href: localizedUrlSlashed('/calcola-stipendio', locale) },
+      { label: LINKS.searchJobsCh[locale], href: localizedUrlSlashed('/cerca-lavoro-svizzera', locale) },
+      { label: LINKS.compareLamal[locale], href: localizedUrlSlashed('/compara-servizi/confronta-casse-malati', locale) },
     ],
   };
 }

--- a/functions/src/newsletterWelcomeEmail.js
+++ b/functions/src/newsletterWelcomeEmail.js
@@ -62,6 +62,43 @@ function toDate(value) {
 // concurrent caller already won the claim — never leaks past this module.
 class WelcomeAlreadySentError extends Error {}
 
+/** Carries the skip reason out of the idempotency transaction. */
+class WelcomeNotEligibleError extends Error {
+  constructor(reason) {
+    super(reason);
+    this.reason = reason;
+  }
+}
+
+/**
+ * Eligibility for a welcome send, from a subscriber doc's data.
+ *
+ * Evaluated twice on purpose: once before the transaction as a cheap early
+ * exit, and again INSIDE it against the freshly-read snapshot. Reading the
+ * state outside and claiming inside would leave a window where an unsubscribe
+ * or a bounce landing between the two still gets a welcome email.
+ *
+ * @param {object} data subscriber doc data
+ * @param {boolean} isPreview preview sends skip the recency window
+ * @returns {{ ok: true } | { ok: false, skipped: string }}
+ */
+function evaluateWelcomeEligibility(data, isPreview) {
+  if (isNewsletterExcluded(data?.status)) {
+    return { ok: false, skipped: 'suppressed' };
+  }
+  const isConfirmed = data?.status === 'confirmed' || data?.isActive === true || data?.active === true;
+  if (!isConfirmed) {
+    return { ok: false, skipped: 'not_confirmed' };
+  }
+  if (!isPreview) {
+    const anchor = toDate(data?.confirmed_at) || toDate(data?.created_at) || toDate(data?.createdAt);
+    if (!anchor || Date.now() - anchor.getTime() > RECENCY_WINDOW_MS) {
+      return { ok: false, skipped: 'too_old' };
+    }
+  }
+  return { ok: true };
+}
+
 /**
  * @param {{email: string, locale?: string, db?: unknown, trigger: 'confirm'|'presigned'|'preview'}} params
  * @returns {Promise<{success: boolean, error?: string, skipped?: string, messageId?: string, segment?: string}>}
@@ -101,20 +138,11 @@ export async function sendNewsletterWelcomeEmail({ email, locale, db: injectedDb
   }
   const data = subscriberDoc.data() || {};
 
-  if (isNewsletterExcluded(data.status)) {
-    return { success: false, skipped: 'suppressed' };
-  }
-
-  const isConfirmed = data.status === 'confirmed' || data.isActive === true || data.active === true;
-  if (!isConfirmed) {
-    return { success: false, skipped: 'not_confirmed' };
-  }
-
-  if (!isPreview) {
-    const anchor = toDate(data.confirmed_at) || toDate(data.created_at) || toDate(data.createdAt);
-    if (!anchor || Date.now() - anchor.getTime() > RECENCY_WINDOW_MS) {
-      return { success: false, skipped: 'too_old' };
-    }
+  // Cheap early exit. The authoritative check runs again inside the
+  // transaction below, against the snapshot read there.
+  const preCheck = evaluateWelcomeEligibility(data, isPreview);
+  if (!preCheck.ok) {
+    return { success: false, skipped: preCheck.skipped };
   }
 
   // Unsubscribe/preferences links are HMAC-signed with this secret — a
@@ -146,8 +174,16 @@ export async function sendNewsletterWelcomeEmail({ email, locale, db: injectedDb
     try {
       await db.runTransaction(async (tx) => {
         const snap = await tx.get(subscriberRef);
-        if (snap.exists && snap.data()?.welcome_sent_at) {
+        const fresh = snap.exists ? (snap.data() || {}) : {};
+        if (fresh.welcome_sent_at) {
           throw new WelcomeAlreadySentError('already_sent');
+        }
+        // Re-verify against the snapshot read in THIS transaction: an
+        // unsubscribe, bounce or complaint landing between the pre-check and
+        // here must still stop the send.
+        const eligible = evaluateWelcomeEligibility(fresh, isPreview);
+        if (!eligible.ok) {
+          throw new WelcomeNotEligibleError(eligible.skipped);
         }
         tx.set(subscriberRef, {
           welcome_sent_at: admin.firestore.FieldValue.serverTimestamp(),
@@ -157,6 +193,9 @@ export async function sendNewsletterWelcomeEmail({ email, locale, db: injectedDb
     } catch (txErr) {
       if (txErr instanceof WelcomeAlreadySentError) {
         return { success: false, skipped: 'already_sent' };
+      }
+      if (txErr instanceof WelcomeNotEligibleError) {
+        return { success: false, skipped: txErr.reason };
       }
       throw txErr;
     }

--- a/tests/newsletter-welcome-email.test.ts
+++ b/tests/newsletter-welcome-email.test.ts
@@ -231,6 +231,34 @@ describe('sendNewsletterWelcomeEmail', () => {
     expect(results.filter((r) => r.skipped === 'already_sent')).toHaveLength(1);
   });
 
+  it.each([
+    ['unsubscribed', 'suppressed'],
+    ['bounced', 'suppressed'],
+  ])(
+    'status flipping to "%s" between the pre-check and the transaction still stops the send',
+    async (status, expectedSkip) => {
+      // The eligibility guards run once as a cheap early exit and again inside
+      // the transaction. Without the in-transaction re-check, an unsubscribe
+      // landing in that window would still be emailed. Simulate it by flipping
+      // the doc just before the transaction body executes.
+      const { sendNewsletterWelcomeEmail } = await import('../functions/src/newsletterWelcomeEmail.js');
+      const db = createFakeDb({ newsletter_subscribers: { 'racer@example.com': recentDoc() } });
+
+      const realRunTransaction = db.runTransaction.bind(db);
+      db.runTransaction = ((fn: Parameters<typeof db.runTransaction>[0]) => {
+        db.docs['newsletter_subscribers/racer@example.com'].status = status;
+        return realRunTransaction(fn);
+      }) as typeof db.runTransaction;
+
+      const result = await sendNewsletterWelcomeEmail({ email: 'racer@example.com', locale: 'it', db, trigger: 'confirm' });
+
+      expect(result).toEqual({ success: false, skipped: expectedSkip });
+      expect(sendEmailCascadeMock).not.toHaveBeenCalled();
+      // The claim must not survive a rejected transaction.
+      expect(db.docs['newsletter_subscribers/racer@example.com'].welcome_sent_at).toBeUndefined();
+    },
+  );
+
   // ── Suppression ──────────────────────────────────────────────
   it.each(['bounced', 'complained', 'suppressed', 'unsubscribed', 'inactive'])(
     'skips suppressed status "%s", sends nothing',


### PR DESCRIPTION
Chiude i tre rilievi della review di #4910 (0 Important, 2 🟡 Nit, 1 ❓ adversarial). Nessuno bloccava il merge, ma uno è un difetto di correttezza reale e gli altri due sono trappole per chi tocca questo codice dopo.

La welcome email è live in produzione: `Deploy Cloud Functions` verde su `ef9dfb44cf7` e l'endpoint risponde davvero — `POST` con indirizzo inesistente → `200 {"success":true}` (opaco), `GET` → `405`, email malformata → `400`.

## Implementato

**Ri-verifica dell'idoneità dentro la transazione** (era il ❓ adversarial) — `functions/src/newsletterWelcomeEmail.js`
- Soppressione, stato confermato e finestra di recenza venivano letti **una volta sola**, prima della transazione che rivendica `welcome_sent_at`; la transazione ri-verificava solo la rivendicazione. Una disiscrizione, un bounce o un reclamo che arrivavano in quella finestra ricevevano comunque la welcome.
- I tre controlli ora vivono in un solo helper `evaluateWelcomeEligibility`, valutato due volte: come uscita rapida prima, e di nuovo **dentro** la transazione sullo snapshot letto lì. Un solo posto da cambiare, nessuna duplicazione della regola.
- Il test di regressione capovolge lo `status` subito prima che parta il corpo della transazione e verifica che non parta nulla e che **la rivendicazione non sopravviva**. Ho controllato che non sia vacuo: rimuovendo il controllo, il test fallisce (2 rossi); rimettendolo, 34 verdi.

**Commento fuorviante sull'endpoint** (🟡) — `functions/index.js`
- Diceva che `newsletterSendWelcome` esiste "per un resend/retry path". In realtà è l'**unico** touchpoint di welcome per gli iscritti pre-confermati — One Tap, login social, gate offerta: circa l'82% delle iscrizioni, che non passano mai dal doppio opt-in. Ora il commento dice cosa serve sapere prima di toccarlo: se si rompe, la maggioranza dei nuovi iscritti non riceve nulla e in silenzio.

**Collisione di naming** (🟡) — `functions/src/lib/welcomeEmailTemplate.js`
- Definiva `directUrl`/`localizedUrl` locali che ombreggiano le canoniche omonime di `newsletterUrlPaths.js` con comportamento diverso sullo slash finale — proprio nella PR che introduceva la regola anti-drift. Rinominate in `directUrlSlashed`/`localizedUrlSlashed`, così l'import sbagliato non è più possibile per distrazione.

## Non implementato (ancora)

Nessuno.

## Test plan

- [x] Suite completa: 1358 file / 138.506 test verdi
- [x] Il test di regressione fallisce senza il fix (2 rossi) e passa con (34 verdi) — non è vacuo
- [x] `node --check` su `functions/index.js`, `newsletterWelcomeEmail.js`, `welcomeEmailTemplate.js`
- [x] Endpoint verificato live in produzione dopo il deploy di #4910 (200 opaco / 405 / 400)
- [ ] Post-merge: prima welcome reale osservata su un iscritto nuovo, con `welcome_sent_at` e `drip_last_step = 0` sul doc

## Nota

`tests/health-facilities.test.ts` va in timeout (21,4s contro un limite di 15s) quando gira dentro la suite intera, e passa in 1,22s da solo. È contesa di CPU sotto carico, non una regressione di questa PR, che non tocca nulla da cui quel test dipenda.
