### PR TITLE
fix(fast-publish): pubblica sitemap e chunk solo dopo che lo shard è live (#4881)

### DIFF
--- a/.github/workflows/fast-publish-article.yml
+++ b/.github/workflows/fast-publish-article.yml
@@ -160,39 +160,6 @@ jobs:
           done
           exit "$fail"
 
-      # Issue #4881 Fase 3-bis — publishes the client-side data chunks
-      # (blog-articles-data.js / swiss-articles-data.js) plus a slim
-      # news-ticker payload OUTSIDE the full build, so the in-app article
-      # list, in-app search AND the homepage news ticker see this article
-      # without waiting for deploy.yml. Same best-effort posture as the CDN
-      # image upload step above: NEVER blocks the publish (see
-      # scripts/publish-article-chunks.mjs header comment for the full
-      # chunk-stability + CDN cache-freshness analysis).
-      - name: Publish client-side article data chunks
-        if: steps.render.outcome == 'success'
-        continue-on-error: true
-        run: npx -y tsx@4 scripts/publish-article-chunks.mjs
-
-      # Issue #4881 Fase 3 (pushable-origin edge files). Independent of the
-      # per-article render above: public/sitemap-blog-ch.xml was already
-      # regenerated and committed by scripts/create-article.mjs in the SAME
-      # commit checked out at the top of this job. The llms.txt family
-      # (added as a residual — see EDGE_PUSHED_FILES's own comment in
-      # locale-router.js) is NOT committed by create-article.mjs at all;
-      # publish-edge-files.mjs renders it itself into a scratch dir (via
-      # `npx -y tsx@4 scripts/generate-llms-txt.mjs`, spawned internally —
-      # no separate step needed here) before PUTting it, same as the
-      # already-committed sitemap file. Gated on render only to match this
-      # file's own convention of not running later steps once an earlier
-      # ungated step has failed the job. NEVER blocks the publish: a failed
-      # render/PUT/purge here just means those apex paths keep serving their
-      # previous R2 copy (or fall open to the origin passthrough) until this
-      # step succeeds on a later run or the next full deploy.
-      - name: Publish edge files (sitemap/RSS + llms.txt pushable origin)
-        if: steps.render.outcome == 'success'
-        continue-on-error: true
-        run: node scripts/publish-edge-files.mjs
-
       # Mirrors the fault-tolerant parallel-push pattern at deploy.yml
       # (`push-section-shard.sh` loop, MAX_PARALLEL / `|| fail=1` / `wait`) —
       # incident 2026-07-24 (run 30057726623): one section's push failure
@@ -255,6 +222,46 @@ jobs:
         id: verify
         if: steps.render.outcome == 'success'
         run: node scripts/wait-for-live-article-shards.mjs /tmp/fast-publish/summary.json
+
+      # Ordering (post-merge review #4908): BOTH publish steps below run only
+      # once the shard is CONFIRMED live. They advertise the article's URL —
+      # the sitemap/RSS to crawlers, the data chunks to the in-app list and
+      # search — so running them before the page exists reintroduces exactly
+      # the bug the verify gate above was added to kill (see its comment).
+      # Best-effort as before: a failure here just means those paths keep
+      # serving their previous copy until a later run or the next full deploy.
+      # Issue #4881 Fase 3-bis — publishes the client-side data chunks
+      # (blog-articles-data.js / swiss-articles-data.js) plus a slim
+      # news-ticker payload OUTSIDE the full build, so the in-app article
+      # list, in-app search AND the homepage news ticker see this article
+      # without waiting for deploy.yml. Same best-effort posture as the CDN
+      # image upload step above: NEVER blocks the publish (see
+      # scripts/publish-article-chunks.mjs header comment for the full
+      # chunk-stability + CDN cache-freshness analysis).
+      - name: Publish client-side article data chunks
+        if: steps.verify.outcome == 'success'
+        continue-on-error: true
+        run: npx -y tsx@4 scripts/publish-article-chunks.mjs
+
+      # Issue #4881 Fase 3 (pushable-origin edge files). Independent of the
+      # per-article render above: public/sitemap-blog-ch.xml was already
+      # regenerated and committed by scripts/create-article.mjs in the SAME
+      # commit checked out at the top of this job. The llms.txt family
+      # (added as a residual — see EDGE_PUSHED_FILES's own comment in
+      # locale-router.js) is NOT committed by create-article.mjs at all;
+      # publish-edge-files.mjs renders it itself into a scratch dir (via
+      # `npx -y tsx@4 scripts/generate-llms-txt.mjs`, spawned internally —
+      # no separate step needed here) before PUTting it, same as the
+      # already-committed sitemap file. Gated on render only to match this
+      # file's own convention of not running later steps once an earlier
+      # ungated step has failed the job. NEVER blocks the publish: a failed
+      # render/PUT/purge here just means those apex paths keep serving their
+      # previous R2 copy (or fall open to the origin passthrough) until this
+      # step succeeds on a later run or the next full deploy.
+      - name: Publish edge files (sitemap/RSS + llms.txt pushable origin)
+        if: steps.verify.outcome == 'success'
+        continue-on-error: true
+        run: node scripts/publish-edge-files.mjs
 
       # Google Indexing API AND IndexNow (Bing/Yandex), with the same verified
       # URL list. IndexNow is included deliberately: its normal driver

--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -327,7 +327,12 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/shard-clone-cache
-          key: shard-clone-cache-${{ github.run_id }}-${{ github.job }}-restore
+          # Primary key mirrors the save key below EXACTLY, so a same-job
+          # re-run hits directly. The cross-JOB hit this cache exists for
+          # comes from the restore-keys prefix instead — the previous
+          # `-restore` suffix could never match any save key, leaving the
+          # primary key dead weight (post-merge review #4908).
+          key: shard-clone-cache-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}
           restore-keys: |
             shard-clone-cache-${{ github.run_id }}-
 
@@ -692,7 +697,12 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/shard-clone-cache
-          key: shard-clone-cache-${{ github.run_id }}-${{ github.job }}-restore
+          # Primary key mirrors the save key below EXACTLY, so a same-job
+          # re-run hits directly. The cross-JOB hit this cache exists for
+          # comes from the restore-keys prefix instead — the previous
+          # `-restore` suffix could never match any save key, leaving the
+          # primary key dead weight (post-merge review #4908).
+          key: shard-clone-cache-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}
           restore-keys: |
             shard-clone-cache-${{ github.run_id }}-
 
@@ -1226,7 +1236,12 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/shard-clone-cache
-          key: shard-clone-cache-${{ github.run_id }}-${{ github.job }}-restore
+          # Primary key mirrors the save key below EXACTLY, so a same-job
+          # re-run hits directly. The cross-JOB hit this cache exists for
+          # comes from the restore-keys prefix instead — the previous
+          # `-restore` suffix could never match any save key, leaving the
+          # primary key dead weight (post-merge review #4908).
+          key: shard-clone-cache-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}
           restore-keys: |
             shard-clone-cache-${{ github.run_id }}-
 

--- a/scripts/audit-article-corpus-drift.mjs
+++ b/scripts/audit-article-corpus-drift.mjs
@@ -203,7 +203,7 @@ function parseLocaleVerdicts(combinedOutput) {
 // 'fetch-or-liveness' are recorded and printed but do NOT fail the run: they
 // are operational/timing noise (a slow deploy propagation, a transient
 // network blip), not template drift — the thing this audit exists to catch.
-const DIVERGENT_CATEGORIES = new Set(['content-mismatch', 'no-locale-verdicts']);
+const DIVERGENT_CATEGORIES = new Set(['content-mismatch', 'no-locale-verdicts', 'unrecognized-verdicts']);
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -244,6 +244,13 @@ async function main() {
         else if (values.includes('cf-bot-script-only')) category = 'ok-cf-bot-script-only';
         else if (values.includes('render-failure')) category = 'render-failure';
         else if (values.includes('fetch-or-liveness')) category = 'fetch-or-liveness';
+        // Every locale line parsed to 'unknown': none of the four known
+        // stdout shapes matched. Unreachable today, but if the render
+        // script's wording ever drifts this is the branch that would fire —
+        // and falling through to 'ok' here would turn this audit into a
+        // blind spot that reports success while checking nothing, the exact
+        // opposite of its fail-loud contract (post-merge review #4908).
+        else if (values.every((v) => v === 'unknown')) category = 'unrecognized-verdicts';
         else category = 'ok';
       }
 


### PR DESCRIPTION
Chiude i tre 🟡 sollevati dal reviewer su #4908 (mergiata con `## LGTM`, zero 🔴). Nessuno era stato elencato e rinviato: sono fixati qui.

## Implementato

- **Ordinamento degli step in `fast-publish-article.yml`** — i due step che *pubblicizzano* l'articolo ora girano solo dopo che lo shard è confermato live.
- **Chiavi di cache in `post-deploy-validate-dist.yml`** — la primary key della restore non poteva mai fare match; ora rispecchia esattamente la save key.
- **Punto cieco in `audit-article-corpus-drift.mjs`** — verdetti tutti `unknown` non passano più silenziosamente come `ok`.

### 1. Ordinamento — è una regressione di un invariante, non un nit

Il reviewer l'ha classificato 🟡 («rischio indicizzabilità trascurabile»), ma il commento del workflow stesso enuncia il principio violato:

> Only pings search engines once the pages are CONFIRMED live — never before. This is the exact ordering bug fast-publish-article.yml fixes relative to generate-article.yml's old "Notify Google Indexing API" step […] which pinged immediately after dispatching deploy.yml on the false assumption "deploy takes ~2-3 min" (worst measured deploy: 2h04m37s — Google was being sent to crawl a 404).

Pubblicare sitemap/RSS e i chunk dati **prima** del push dello shard è la stessa classe di bug: la sitemap annuncia ai crawler un URL che non esiste ancora, e la lista in-app lo mostra prima che la pagina sia raggiungibile. La finestra è di pochi secondi e si auto-risolve nello stesso run — ma è precisamente l'invariante che il gate `verify` era stato aggiunto per garantire.

Ordine prima → dopo:

```
render → immagini → chunk dati → edge files → push shard → verify → notify
render → immagini → push shard → verify → chunk dati → edge files → notify
```

Entrambi gli step passano da `if: steps.render.outcome == 'success'` a `if: steps.verify.outcome == 'success'`, la stessa condizione di `notify`. Posture invariata: restano best-effort e `continue-on-error`, quindi un fallimento qui non blocca la pubblicazione — quei path continuano a servire la copia precedente fino a un run successivo o al deploy completo.

La causa è mia: i due step arrivavano da due branch diversi e li ho inseriti nello stesso punto risolvendo il conflitto di merge, senza rivalutare la posizione rispetto al gate.

### 2. Chiavi di cache

La restore usava `…-${{ github.job }}-restore`, la save `…-${{ github.job }}-${{ github.run_attempt }}`: il match esatto sulla primary key non poteva avvenire mai, e si cadeva sempre sul prefix match di `restore-keys`. Funzionalmente innocuo — il riuso cross-job avveniva comunque — ma la primary key era peso morto che suggeriva un comportamento inesistente.

Ora la primary key rispecchia esattamente la save key (match diretto su re-run dello stesso job) e un commento dichiara che il riuso **cross-job**, che è la ragione d'essere di questa cache, passa dal prefisso. Applicato a tutte e 3 le occorrenze.

### 3. Punto cieco nell'audit di deriva

Se tutti i verdetti di una locale erano `unknown` — nessuna delle quattro forme note di output riconosciuta — il codice cadeva nel default `category = 'ok'`. Oggi irraggiungibile, ma se il wording dei log dello script di render cambiasse, l'audit riporterebbe successo **senza aver verificato nulla**: l'esatto opposto del contratto fail-loud che lo script dichiara.

Aggiunto un ramo esplicito `unrecognized-verdicts`, incluso in `DIVERGENT_CATEGORIES` perché fallisca invece di passare.

## Non implementato (ancora)

Nessuno.

## Note per il reviewer

- `lint-gha-node-runtime`: `OK — 493 first-party action ref(s) on Node ≥ 24`.
- vitest sulle aree toccate: 5 file, 46 test verdi, eseguiti con `GIT_CONFIG_GLOBAL` puntato a una config con `init.defaultBranch=master` per riprodurre il default del runner invece di quello locale.
- Nessuna soglia abbassata, nessun errore declassato a warning: il fix #3 rende l'audit **più** severo, non meno.
