### PR TITLE
fix(drift-audit): chiude davvero il punto cieco + guardia di invocazione sui fratelli (#4881)

### DIFF
--- a/scripts/audit-article-corpus-drift.mjs
+++ b/scripts/audit-article-corpus-drift.mjs
@@ -158,7 +158,7 @@ function sampleWithoutReplacement(arr, n) {
 //     article still propagating; see header comment).
 //   - 'content-mismatch'    — a real MISMATCH with no CF marker in its
 //     reported diff block: the signal this audit actually exists to catch.
-function parseLocaleVerdicts(combinedOutput) {
+export function parseLocaleVerdicts(combinedOutput) {
   const verdicts = {};
   let currentLocale = null;
   let currentBlockLines = [];
@@ -203,6 +203,36 @@ function parseLocaleVerdicts(combinedOutput) {
 // 'fetch-or-liveness' are recorded and printed but do NOT fail the run: they
 // are operational/timing noise (a slow deploy propagation, a transient
 // network blip), not template drift — the thing this audit exists to catch.
+/**
+ * Collapses the per-locale verdicts of one article into a single category.
+ *
+ * Pure and exported so the precedence order is unit-testable: it has been
+ * wrong twice. The first version fell through to 'ok' whenever no known
+ * verdict matched; the second only caught the all-'unknown' case, so a mix
+ * (it=ok, en=unknown) still passed silently with en never actually verified
+ * — the same blind spot, just narrowed (reviewer finding on PR #4914).
+ *
+ * Precedence, and why:
+ *   1. no-locale-verdicts — the checker never printed a single line.
+ *   2. content-mismatch   — real drift, the thing this audit exists to catch.
+ *   3. unrecognized-verdicts — ANY locale unparseable. Outranks the tolerated
+ *      noise below: 'it=cf-bot-script-only, en=unknown' must not report as a
+ *      pass, because en was never verified at all.
+ *   4-5. render-failure / fetch-or-liveness — operational noise, reported but
+ *      not failing (see DIVERGENT_CATEGORIES).
+ *   6. ok.
+ */
+export function categorizeLocaleVerdicts(localeVerdicts) {
+  const values = Object.values(localeVerdicts ?? {});
+  if (values.length === 0) return 'no-locale-verdicts';
+  if (values.includes('content-mismatch')) return 'content-mismatch';
+  if (values.includes('unknown')) return 'unrecognized-verdicts';
+  if (values.includes('cf-bot-script-only')) return 'ok-cf-bot-script-only';
+  if (values.includes('render-failure')) return 'render-failure';
+  if (values.includes('fetch-or-liveness')) return 'fetch-or-liveness';
+  return 'ok';
+}
+
 const DIVERGENT_CATEGORIES = new Set(['content-mismatch', 'no-locale-verdicts', 'unrecognized-verdicts']);
 
 async function main() {
@@ -229,30 +259,8 @@ async function main() {
       });
       const combinedOutput = `${result.stdout || ''}\n${result.stderr || ''}`;
       const localeVerdicts = parseLocaleVerdicts(combinedOutput);
-      const hasVerdicts = Object.keys(localeVerdicts).length > 0;
 
-      let category;
-      if (!hasVerdicts) {
-        // check-article-byte-identity.mjs never got far enough to print a
-        // single per-locale line (e.g. publish-article-fast.mjs itself
-        // failed) — cannot categorize, so this counts as a finding rather
-        // than a silent pass.
-        category = 'no-locale-verdicts';
-      } else {
-        const values = Object.values(localeVerdicts);
-        if (values.includes('content-mismatch')) category = 'content-mismatch';
-        else if (values.includes('cf-bot-script-only')) category = 'ok-cf-bot-script-only';
-        else if (values.includes('render-failure')) category = 'render-failure';
-        else if (values.includes('fetch-or-liveness')) category = 'fetch-or-liveness';
-        // Every locale line parsed to 'unknown': none of the four known
-        // stdout shapes matched. Unreachable today, but if the render
-        // script's wording ever drifts this is the branch that would fire —
-        // and falling through to 'ok' here would turn this audit into a
-        // blind spot that reports success while checking nothing, the exact
-        // opposite of its fail-loud contract (post-merge review #4908).
-        else if (values.every((v) => v === 'unknown')) category = 'unrecognized-verdicts';
-        else category = 'ok';
-      }
+      const category = categorizeLocaleVerdicts(localeVerdicts);
 
       const ok = !DIVERGENT_CATEGORIES.has(category);
       if (!ok) anyDivergence = true;
@@ -281,7 +289,19 @@ async function main() {
   console.log('[audit-article-corpus-drift] PASS — no divergence found in this sample');
 }
 
-main().catch((err) => {
-  console.error('[audit-article-corpus-drift] fatal error:', err);
-  process.exit(1);
-});
+// Run as standalone only if invoked directly. Same idiom as
+// scripts/audit-footer-root-presence.mjs and siblings — without it, merely
+// IMPORTING this module (as tests/audit-article-corpus-drift-categorize.test.ts
+// does to reach the pure categorizer) would execute the whole audit: spawn
+// `npx tsx` per sampled article, hit the live site, and call process.exit.
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('[audit-article-corpus-drift] fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/notify-article-search-engines.mjs
+++ b/scripts/notify-article-search-engines.mjs
@@ -82,7 +82,17 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(`[notify-search-engines] unexpected error: ${err?.message || err}`);
-  // Deliberately exit 0 — see the header contract.
-});
+// Run as standalone only if invoked directly (repo idiom — see
+// scripts/audit-footer-root-presence.mjs). Guards against a plain `import`
+// of this module executing its whole side-effecting run.
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error(`[notify-search-engines] unexpected error: ${err?.message || err}`);
+    // Deliberately exit 0 — see the header contract.
+  });
+}

--- a/scripts/publish-edge-files.mjs
+++ b/scripts/publish-edge-files.mjs
@@ -164,9 +164,19 @@ function main() {
   }
 }
 
-try {
-  main();
-} catch (err) {
-  console.error(`::error::[publish-edge-files] unexpected failure: ${err.message}`);
-  process.exit(1);
+// Run as standalone only if invoked directly (repo idiom — see
+// scripts/audit-footer-root-presence.mjs). Guards against a plain `import`
+// of this module executing its whole side-effecting run.
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`::error::[publish-edge-files] unexpected failure: ${err.message}`);
+    process.exit(1);
+  }
 }

--- a/scripts/rerender-article-corpus.mjs
+++ b/scripts/rerender-article-corpus.mjs
@@ -400,7 +400,17 @@ async function main() {
   await runOrchestrator(args);
 }
 
-main().catch((err) => {
-  console.error('[rerender-article-corpus] fatal error:', err);
-  process.exit(1);
-});
+// Run as standalone only if invoked directly (repo idiom — see
+// scripts/audit-footer-root-presence.mjs). Guards against a plain `import`
+// of this module executing its whole side-effecting run.
+const invokedDirectly = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]); }
+  catch { return false; }
+})();
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('[rerender-article-corpus] fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/tests/audit-article-corpus-drift-categorize.test.ts
+++ b/tests/audit-article-corpus-drift-categorize.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Pins the verdict-precedence of `categorizeLocaleVerdicts`
+ * (scripts/audit-article-corpus-drift.mjs).
+ *
+ * This logic has been wrong twice. Both regressions had the same shape: a
+ * verdict the code could not interpret fell through to `'ok'`, so the audit
+ * reported success while having verified nothing — the exact opposite of the
+ * fail-loud contract the script states for itself.
+ *
+ *   1st (PR #4908): no `'unknown'` branch at all.
+ *   2nd (PR #4914): a branch that only fired when EVERY locale was
+ *      `'unknown'`, so a mix (it=ok, en=unknown) still passed silently.
+ *
+ * Hence these tests assert the precedence directly rather than the happy
+ * path only: the mixed cases are where the bug lived both times.
+ */
+import { describe, it, expect } from 'vitest';
+import { categorizeLocaleVerdicts } from '../scripts/audit-article-corpus-drift.mjs';
+
+describe('categorizeLocaleVerdicts — precedence', () => {
+  it('reports no-locale-verdicts when the checker printed nothing', () => {
+    expect(categorizeLocaleVerdicts({})).toBe('no-locale-verdicts');
+    expect(categorizeLocaleVerdicts(undefined)).toBe('no-locale-verdicts');
+  });
+
+  it('reports ok only when every locale is genuinely ok', () => {
+    expect(categorizeLocaleVerdicts({ it: 'ok', en: 'ok', de: 'ok', fr: 'ok' })).toBe('ok');
+  });
+
+  it('reports content-mismatch — real drift outranks everything else', () => {
+    expect(
+      categorizeLocaleVerdicts({ it: 'content-mismatch', en: 'unknown', de: 'ok', fr: 'render-failure' }),
+    ).toBe('content-mismatch');
+  });
+
+  // The 2nd-regression case: a single unparseable locale among healthy ones.
+  it('reports unrecognized-verdicts when even ONE locale is unknown', () => {
+    expect(categorizeLocaleVerdicts({ it: 'ok', en: 'unknown', de: 'ok', fr: 'ok' })).toBe(
+      'unrecognized-verdicts',
+    );
+  });
+
+  // The 1st-regression case.
+  it('reports unrecognized-verdicts when every locale is unknown', () => {
+    expect(categorizeLocaleVerdicts({ it: 'unknown', en: 'unknown', de: 'unknown', fr: 'unknown' })).toBe(
+      'unrecognized-verdicts',
+    );
+  });
+
+  it('lets unknown outrank tolerated noise, so a partial check never reads as a pass', () => {
+    expect(categorizeLocaleVerdicts({ it: 'cf-bot-script-only', en: 'unknown' })).toBe(
+      'unrecognized-verdicts',
+    );
+    expect(categorizeLocaleVerdicts({ it: 'render-failure', en: 'unknown' })).toBe('unrecognized-verdicts');
+    expect(categorizeLocaleVerdicts({ it: 'fetch-or-liveness', en: 'unknown' })).toBe(
+      'unrecognized-verdicts',
+    );
+  });
+
+  it('keeps the tolerated-noise ordering among themselves', () => {
+    expect(categorizeLocaleVerdicts({ it: 'cf-bot-script-only', en: 'render-failure' })).toBe(
+      'ok-cf-bot-script-only',
+    );
+    expect(categorizeLocaleVerdicts({ it: 'render-failure', en: 'fetch-or-liveness' })).toBe(
+      'render-failure',
+    );
+    expect(categorizeLocaleVerdicts({ it: 'fetch-or-liveness', en: 'ok' })).toBe('fetch-or-liveness');
+  });
+
+  it('fails the run for exactly the categories that mean "not verified"', async () => {
+    // Guards the pairing between the precedence above and the failing set:
+    // a category can only be added to one without considering the other.
+    const src = await import('node:fs').then((fs) =>
+      fs.readFileSync(new URL('../scripts/audit-article-corpus-drift.mjs', import.meta.url), 'utf8'),
+    );
+    const m = /const DIVERGENT_CATEGORIES = new Set\(\[([^\]]*)\]\)/.exec(src);
+    expect(m).not.toBeNull();
+    const divergent = [...m![1].matchAll(/'([^']+)'/g)].map((x) => x[1]).sort();
+    expect(divergent).toEqual(['content-mismatch', 'no-locale-verdicts', 'unrecognized-verdicts'].sort());
+  });
+});


### PR DESCRIPTION
Il reviewer di #4914 aveva ragione: il mio fix al punto cieco dell'audit di deriva era **incompleto**, e il commento che avevo scritto dichiarava di averlo chiuso. Questa PR lo chiude davvero, e sana la classe di difetto che è emersa cercando di testarlo.

## Implementato

- **Punto cieco chiuso per davvero** — `unknown` su *qualsiasi* locale, non solo su tutte.
- **Precedenza estratta in funzione pura e testata** — questa logica ha sbagliato due volte.
- **Guardia di invocazione diretta su 4 script** — importarne uno ne eseguiva l'intero run.

### 1. Il fix precedente era incompleto

`values.every((v) => v === 'unknown')` catturava solo il caso in cui *tutte* le locale erano illeggibili. Un misto — `it=ok, en=unknown` — non matchava nessun `.includes()` sopra né quell'`.every()`, e ricadeva nel default `category = 'ok'`: **`en` non era stato verificato affatto, ma l'audit riportava successo.** Lo stesso punto cieco, solo ristretto.

Ora il predicato è `values.includes('unknown')`, e la sua posizione nella catena conta: sta **sopra** le categorie di rumore tollerato. Altrimenti `it=cf-bot-script-only, en=unknown` verrebbe riportato come `ok-cf-bot-script-only`, nascondendo di nuovo l'`unknown`.

Precedenza finale, con la ragione di ciascun gradino documentata nel codice:

```
no-locale-verdicts → content-mismatch → unrecognized-verdicts
  → ok-cf-bot-script-only → render-failure → fetch-or-liveness → ok
```

### 2. Estrazione e test

`categorizeLocaleVerdicts` è ora una funzione pura esportata, con `tests/audit-article-corpus-drift-categorize.test.ts` (8 test) che fissa la precedenza. I test coprono esplicitamente **entrambe le regressioni storiche** — nessun ramo `unknown` (#4908) e ramo solo-tutte-unknown (#4914) — perché è lì che il bug è vissuto tutte e due le volte, non sul percorso felice.

Un test aggiuntivo lega la catena di precedenza a `DIVERGENT_CATEGORIES`, così non si può aggiungere una categoria all'una senza considerare l'altra.

### 3. La classe di difetto scoperta scrivendo il test

Il test non riusciva a chiudere il processo: `scripts/audit-article-corpus-drift.mjs` chiamava `main()` **al caricamento del modulo**. Un semplice `import` eseguiva l'intero audit — spawn di `npx tsx` per articolo campionato, richieste al sito live, `process.exit`.

Applicata la guardia già in uso nel repo (`scripts/audit-footer-root-presence.mjs:194-197`), non una nuova. Grep dei fratelli nati da questo lavoro, e la classe è più larga di un file:

| Script | Stato |
|---|---|
| `audit-article-corpus-drift.mjs` | difetto originale — guardato |
| `rerender-article-corpus.mjs` | stesso difetto (Fase 4) — guardato |
| `publish-edge-files.mjs` | stesso difetto in forma `try { main() }` (Fase 3) — guardato |
| `notify-article-search-engines.mjs` | stesso difetto, **preesistente** (#4837) — guardato |
| `publish-article-chunks.mjs` | già corretto — nessuna modifica |

### Verifica reale delle due modalità

La guardia non doveva rompere l'invocazione da CLI, che è come i workflow li usano. Eseguiti davvero, non dedotti:

- `rerender-article-corpus.mjs --section svizzera --dry-run --limit 2` → renderizza 2 articoli in una dist di scratch, scrive il manifest, salta il push per il dry-run, **exit 0**. Conferma anche che il sotto-processo worker, che si auto-invoca, passa la guardia.
- `publish-edge-files.mjs` → genera la famiglia `llms.txt` reale (indice di 3774 URL) prima della PUT.
- `notify-article-search-engines.mjs --summary /nonexistent.json` → entra in `main`, degrada correttamente.
- `npx vitest run tests/audit-article-corpus-drift-categorize.test.ts` → **8/8 verdi**, e il processo ora esce.

## Non implementato (ancora)

Nessuno.

## Note per il reviewer

- Il fix rende l'audit **più** severo, non meno: nessuna soglia toccata, nessun errore declassato.
- La guardia è l'idioma già presente nel repo, non una seconda implementazione.
