### PR TITLE
test(drift-audit): importa DIVERGENT_CATEGORIES invece di leggerla via regex (#4881)

### DIFF
--- a/scripts/audit-article-corpus-drift.mjs
+++ b/scripts/audit-article-corpus-drift.mjs
@@ -233,7 +233,7 @@ export function categorizeLocaleVerdicts(localeVerdicts) {
   return 'ok';
 }
 
-const DIVERGENT_CATEGORIES = new Set(['content-mismatch', 'no-locale-verdicts', 'unrecognized-verdicts']);
+export const DIVERGENT_CATEGORIES = new Set(['content-mismatch', 'no-locale-verdicts', 'unrecognized-verdicts']);
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));

--- a/tests/audit-article-corpus-drift-categorize.test.ts
+++ b/tests/audit-article-corpus-drift-categorize.test.ts
@@ -15,7 +15,7 @@
  * path only: the mixed cases are where the bug lived both times.
  */
 import { describe, it, expect } from 'vitest';
-import { categorizeLocaleVerdicts } from '../scripts/audit-article-corpus-drift.mjs';
+import { categorizeLocaleVerdicts, DIVERGENT_CATEGORIES } from '../scripts/audit-article-corpus-drift.mjs';
 
 describe('categorizeLocaleVerdicts — precedence', () => {
   it('reports no-locale-verdicts when the checker printed nothing', () => {
@@ -67,15 +67,22 @@ describe('categorizeLocaleVerdicts — precedence', () => {
     expect(categorizeLocaleVerdicts({ it: 'fetch-or-liveness', en: 'ok' })).toBe('fetch-or-liveness');
   });
 
-  it('fails the run for exactly the categories that mean "not verified"', async () => {
+  it('fails the run for exactly the categories that mean "not verified"', () => {
     // Guards the pairing between the precedence above and the failing set:
     // a category can only be added to one without considering the other.
-    const src = await import('node:fs').then((fs) =>
-      fs.readFileSync(new URL('../scripts/audit-article-corpus-drift.mjs', import.meta.url), 'utf8'),
+    // Imports the real Set rather than regex-parsing the source, so a
+    // reformat of the literal cannot silently neuter this assertion
+    // (reviewer finding on PR #4915).
+    expect([...DIVERGENT_CATEGORIES].sort()).toEqual(
+      ['content-mismatch', 'no-locale-verdicts', 'unrecognized-verdicts'].sort(),
     );
-    const m = /const DIVERGENT_CATEGORIES = new Set\(\[([^\]]*)\]\)/.exec(src);
-    expect(m).not.toBeNull();
-    const divergent = [...m![1].matchAll(/'([^']+)'/g)].map((x) => x[1]).sort();
-    expect(divergent).toEqual(['content-mismatch', 'no-locale-verdicts', 'unrecognized-verdicts'].sort());
+  });
+
+  it('never fails the run for a category the precedence can return as a pass', () => {
+    // The other half of the pairing: every non-divergent category the
+    // categorizer can produce must be absent from the failing set.
+    for (const c of ['ok', 'ok-cf-bot-script-only', 'render-failure', 'fetch-or-liveness']) {
+      expect(DIVERGENT_CATEGORIES.has(c)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
Chiude l'ultimo 🟡 di #4915. Due righe di sostanza, ma su un test che protegge logica già sbagliata due volte — quindi meritava la correzione, non il rinvio.

## Implementato

- `DIVERGENT_CATEGORIES` è ora esportata da `scripts/audit-article-corpus-drift.mjs`, e il test la **importa** invece di estrarla dal sorgente con `fs.readFileSync` + regex. Una riformattazione del literal (multi-riga, virgola finale) non può più neutralizzare silenziosamente l'asserzione.
- Aggiunto l'altro lato dell'accoppiamento: un test che verifica che nessuna categoria *non* divergente (`ok`, `ok-cf-bot-script-only`, `render-failure`, `fetch-or-liveness`) finisca nell'insieme che fa fallire il run. Prima era garantito solo il verso opposto.

Perché conta: la coppia precedenza ↔ insieme-che-fallisce è esattamente il punto in cui il bug è vissuto due volte. Un test che legge il sorgente via regex avrebbe continuato a passare anche se il literal fosse stato riscritto in una forma non matchata — cioè avrebbe smesso di controllare senza dirlo, lo stesso modo di fallire dell'audit che protegge.

## Non implementato (ancora)

Nessuno.

## Note per il reviewer

`npx vitest run tests/audit-article-corpus-drift-categorize.test.ts` → **9/9 verdi** (erano 8, +1 per il verso mancante).
