### PR TITLE
feat(email): link autologin, copy consapevole degli avvisi già attivi, blocco consulenza

### DIFF
--- a/functions/src/lib/newsletterUrlPaths.js
+++ b/functions/src/lib/newsletterUrlPaths.js
@@ -53,6 +53,16 @@ export const LOCALE_PATH_MAP = {
     de: '/de/jobs-im-tessin',
     fr: '/fr/trouver-emploi-tessin',
   },
+  // Paid 1:1 consulting. Slugs mirror services/routeSlugs.data.ts `consulting`
+  // (router.ts:3366 builds `${prefix}/${table.consulting}`); the drift test in
+  // tests/route-slugs-no-drift.test.ts asserts the two stay equal, since a
+  // Cloud Function cannot import the TypeScript source.
+  '/consulenza': {
+    it: '/consulenza',
+    en: '/en/consulting',
+    de: '/de/beratung',
+    fr: '/fr/consultation',
+  },
   // Switzerland-wide aggregate job board (data/canton-url-slugs.json →
   // aggregate). The weekly newsletter has no per-subscriber canton context
   // (its "total jobs" metric/CTA counts jobs across every canton), so its

--- a/functions/src/lib/newsletterUrls.js
+++ b/functions/src/lib/newsletterUrls.js
@@ -125,6 +125,66 @@ export function makeAuthenticatedActionUrl(action, email, { secret } = {}) {
   return code ? `${base}&ac=${code}` : base;
 }
 
+/**
+ * True when an href should carry autologin credentials: our own site only,
+ * never mailto/tel/anchors, never static assets.
+ * @param {string} rawHref
+ * @returns {boolean}
+ */
+export function shouldWrapAuthenticatedHref(rawHref) {
+  if (!rawHref) return false;
+  if (rawHref.startsWith('mailto:') || rawHref.startsWith('tel:') || rawHref.startsWith('#')) return false;
+  let url;
+  try { url = new URL(rawHref, BASE_URL); } catch { return false; }
+  if (url.hostname.replace(/^www\./, '') !== 'frontaliereticino.ch') return false;
+  if (url.pathname.startsWith('/images/') || url.pathname.startsWith('/icons/')) return false;
+  return true;
+}
+
+/**
+ * Add autologin credentials to one of our own URLs so the recipient lands
+ * signed in. `ne`/`ac` are deliberately short: Mailgun silently drops click
+ * tracking for href values >= 1000 characters.
+ *
+ * utm_medium stays 'newsletter' because GA4's Email channel grouping keys on
+ * it; pass utmCampaign to keep campaigns separable within that channel.
+ *
+ * @param {string} targetUrl absolute or site-relative
+ * @param {string} email
+ * @param {{secret?: string, autologinCode?: string|null, utmCampaign?: string|null}} [opts]
+ * @returns {string}
+ */
+export function makeAuthenticatedUrl(targetUrl, email, { secret, autologinCode, utmCampaign } = {}) {
+  const url = new URL(targetUrl, BASE_URL);
+  const code = autologinCode === undefined ? generateAutologinCode(email, { secret }) : autologinCode;
+  url.searchParams.set('ne', String(email || '').toLowerCase());
+  if (code) url.searchParams.set('ac', code);
+  url.searchParams.set('utm_medium', 'newsletter');
+  if (utmCampaign) url.searchParams.set('utm_campaign', utmCampaign);
+  return url.toString();
+}
+
+/**
+ * Rewrite every eligible href in an email body to its autologin form. One
+ * code is generated per recipient and reused across links (it never expires),
+ * so this costs a single HMAC regardless of link count.
+ *
+ * @param {string} html
+ * @param {string} email
+ * @param {{secret?: string, utmCampaign?: string|null}} [opts]
+ * @returns {string}
+ */
+export function wrapAuthenticatedHrefs(html, email, { secret, utmCampaign } = {}) {
+  if (!html || !email) return html;
+  const autologinCode = generateAutologinCode(email, { secret });
+  return html.replace(/href="([^"]+)"/g, (whole, rawHref) => {
+    const href = rawHref.replace(/&amp;/g, '&');
+    if (!shouldWrapAuthenticatedHref(href)) return whole;
+    const wrapped = makeAuthenticatedUrl(href, email, { secret, autologinCode, utmCampaign });
+    return `href="${wrapped.replace(/&/g, '&amp;')}"`;
+  });
+}
+
 // ── Preferences URL — Cloud-Functions-only. Part of the newsletterWelcomeEmail
 // extraction (AGENTS.md Non-Negotiable #6, docs/AGENTS-HISTORY.md#sibling-pattern-fix).
 // The per-locale slug table below is a RUNTIME COPY of services/routeSlugs.data.ts's

--- a/functions/src/lib/welcomeEmailTemplate.js
+++ b/functions/src/lib/welcomeEmailTemplate.js
@@ -161,6 +161,46 @@ const JOB_HOOK_TEMPLATE = {
   fr: (d) => `Tu t’es inscrit en consultant ${d}. Tu n’as plus besoin de vérifier à la main : crée une alerte emploi avec ces critères et on t’écrit dès qu’une nouveauté correspond.`,
 };
 
+// Alerts are created automatically at signup by the
+// backfillJobAlertOnNewsletterSignup trigger, so for most `job` arrivals the
+// alert is ALREADY live when this email lands. Asking them to "create a job
+// alert" would request something already done, so the copy switches to
+// confirming it and offering to refine it instead.
+const JOB_HOOK_ACTIVE_TEMPLATE = {
+  it: (d) => `Ti sei iscritto mentre guardavi ${d}. Gli avvisi sono già attivi su questi criteri: da ora ti scriviamo noi appena esce un’offerta che corrisponde, non devi più controllare a mano.`,
+  en: (d) => `You signed up while looking at ${d}. Your alerts are already running on those criteria: from now on we email you the moment a matching role appears, so you don’t have to keep checking.`,
+  de: (d) => `Du hast dich angemeldet, während du dir ${d} angesehen hast. Deine Job-Alerts laufen bereits mit diesen Kriterien: Ab jetzt schreiben wir dir, sobald eine passende Stelle erscheint — manuelles Nachsehen entfällt.`,
+  fr: (d) => `Tu t’es inscrit en consultant ${d}. Tes alertes sont déjà actives sur ces critères : à partir de maintenant on t’écrit dès qu’une offre correspond, plus besoin de vérifier à la main.`,
+};
+
+const JOB_SUBJECT_ACTIVE = {
+  it: 'Sei dentro: gli avvisi lavoro sono attivi',
+  en: 'You’re in: your job alerts are live',
+  de: 'Du bist dabei: deine Job-Alerts laufen',
+  fr: 'C’est fait : tes alertes emploi sont actives',
+};
+
+const JOB_PREHEADER_ACTIVE = {
+  it: 'Ti scriviamo noi appena esce un’offerta che corrisponde ai tuoi criteri.',
+  en: 'We’ll email you the moment a role matching your criteria shows up.',
+  de: 'Wir melden uns, sobald eine Stelle zu deinen Kriterien passt.',
+  fr: 'On t’écrit dès qu’une offre correspond à tes critères.',
+};
+
+const JOB_HEADING_ACTIVE = {
+  it: 'I tuoi avvisi sono già attivi',
+  en: 'Your job alerts are already on',
+  de: 'Deine Job-Alerts sind schon aktiv',
+  fr: 'Tes alertes sont déjà actives',
+};
+
+const JOB_CTA_ACTIVE = {
+  it: 'Affina i tuoi avvisi →',
+  en: 'Fine-tune your alerts →',
+  de: 'Job-Alerts anpassen →',
+  fr: 'Affiner tes alertes →',
+};
+
 // ── Utility segment tool naming (TOOL_KEYS contract: lamal, wizard,
 // leadmagnet, selfcert, calculator, comparator) ─────────────────────
 const TOOL_LABELS = {
@@ -342,14 +382,55 @@ function renderCredibility(text) {
   return `<tr><td class="section-pad" style="padding:0 28px 16px;"><div style="font-size:12px;color:${MUTED_COLOR};text-align:center;">${escapeHtml(text)}</div></td></tr>`;
 }
 
+const CONSULTING = {
+  it: {
+    title: 'Hai una situazione che non torna?',
+    body: 'Doppia imposizione, permesso, rientro dei redditi, telelavoro oltre soglia: se il tuo caso non lo risolve un calcolatore, puoi parlarne con noi in una consulenza dedicata.',
+    cta: 'Vedi come funziona la consulenza',
+  },
+  en: {
+    title: 'Got a situation the tools can’t settle?',
+    body: 'Double taxation, permits, declaring Swiss income in Italy, remote work past the threshold: when a calculator isn’t enough, you can talk it through with us in a one-to-one session.',
+    cta: 'See how a consultation works',
+  },
+  de: {
+    title: 'Ein Fall, den kein Rechner löst?',
+    body: 'Doppelbesteuerung, Bewilligung, Deklaration in Italien, Homeoffice über der Schwelle: Wenn ein Rechner nicht reicht, kannst du deinen Fall in einer persönlichen Beratung besprechen.',
+    cta: 'So läuft eine Beratung ab',
+  },
+  fr: {
+    title: 'Une situation que les outils ne règlent pas ?',
+    body: 'Double imposition, permis, déclaration des revenus en Italie, télétravail au-delà du seuil : quand un calculateur ne suffit pas, tu peux en parler avec nous lors d’une consultation dédiée.',
+    cta: 'Voir comment se passe une consultation',
+  },
+};
+
+function renderConsulting(locale) {
+  const c = CONSULTING[locale] || CONSULTING.it;
+  const href = localizedUrlSlashed('/consulenza', locale);
+  return `<tr><td class="section-pad" style="padding:0 28px 20px;">
+      <table width="100%" cellpadding="0" cellspacing="0" style="background:${CARD_BG};border:1px solid ${BORDER_COLOR};border-radius:12px;">
+        <tr><td style="padding:16px 18px;">
+          <div style="font-size:14px;font-weight:800;color:${BRAND_DARK};padding-bottom:6px;">${escapeHtml(c.title)}</div>
+          <div style="font-size:13px;line-height:1.6;color:${TEXT_COLOR};padding-bottom:12px;">${escapeHtml(c.body)}</div>
+          <a target="_blank" rel="noopener noreferrer" href="${escapeHtml(href)}" style="font-size:13px;font-weight:700;color:${BRAND_ORANGE};text-decoration:none;">${escapeHtml(c.cta)} →</a>
+        </td></tr>
+      </table>
+    </td></tr>`;
+}
+
 function renderDeliverability(text) {
   return `<tr><td class="section-pad" style="padding:0 28px 20px;"><div style="font-size:12px;color:${MUTED_COLOR};text-align:center;line-height:1.5;">${escapeHtml(text)}</div></td></tr>`;
 }
 
 // ── Per-segment content builders ─────────────────────────────────
-function buildJobContent(locale, { company, sectorKey, locationLabel, jobBackPath }) {
+function buildJobContent(locale, { company, sectorKey, locationLabel, jobBackPath, jobAlertActive, preferencesUrl }) {
   const descriptor = buildJobDescriptor(locale, { company, sectorKey, locationLabel });
-  const hook = JOB_HOOK_TEMPLATE[locale](descriptor);
+  // Refining alerts happens on the newsletter-preferences page. Without a
+  // preferences URL (no signing secret) there is nowhere to send them, so fall
+  // back to the create-an-alert wording rather than emitting a dead button.
+  const alertsOn = Boolean(jobAlertActive && preferencesUrl);
+  const hook = (alertsOn ? JOB_HOOK_ACTIVE_TEMPLATE : JOB_HOOK_TEMPLATE)[locale](descriptor);
   const quickLinks = [];
   if (jobBackPath) {
     quickLinks.push({ label: LINKS.backToJob[locale], href: directUrlSlashed(jobBackPath) });
@@ -360,12 +441,12 @@ function buildJobContent(locale, { company, sectorKey, locationLabel, jobBackPat
   quickLinks.push({ label: LINKS.compareLamal[locale], href: localizedUrlSlashed('/compara-servizi/confronta-casse-malati', locale) });
 
   return {
-    subject: SUBJECT.job[locale],
-    preheader: PREHEADER.job[locale],
-    heading: HEADING.job[locale],
+    subject: alertsOn ? JOB_SUBJECT_ACTIVE[locale] : SUBJECT.job[locale],
+    preheader: alertsOn ? JOB_PREHEADER_ACTIVE[locale] : PREHEADER.job[locale],
+    heading: alertsOn ? JOB_HEADING_ACTIVE[locale] : HEADING.job[locale],
     hook,
-    ctaLabel: CTA_LABEL.job[locale],
-    ctaHref: localizedUrlSlashed('/cerca-lavoro-svizzera', locale),
+    ctaLabel: alertsOn ? JOB_CTA_ACTIVE[locale] : CTA_LABEL.job[locale],
+    ctaHref: alertsOn ? preferencesUrl : localizedUrlSlashed('/cerca-lavoro-svizzera', locale),
     quickLinks,
   };
 }
@@ -480,13 +561,16 @@ export function buildWelcomeEmail({
   locationLabel = null,
   jobBackPath = null,
   toolKey = null,
+  jobAlertActive = false,
   unsubscribeUrl,
   preferencesUrl = null,
   acquisitionSource = null,
 }) {
   const lang = normLocale(locale);
   const seg = SEGMENT_BUILDERS[segment] ? segment : 'general';
-  const content = SEGMENT_BUILDERS[seg](lang, { company, sectorKey, locationLabel, jobBackPath, toolKey });
+  const content = SEGMENT_BUILDERS[seg](lang, {
+    company, sectorKey, locationLabel, jobBackPath, toolKey, jobAlertActive, preferencesUrl,
+  });
   const isPublisher = seg === 'publisher';
 
   const unsub = unsubscribeUrl || `${BASE_URL}/?action=unsubscribe`;
@@ -496,6 +580,11 @@ export function buildWelcomeEmail({
   const deliverabilityText = (isPublisher ? DELIVERABILITY.publisher : DELIVERABILITY.consumer)[lang];
   // Publisher is a different audience (employer, not job seeker) — never a
   // consumer affiliate offer in their welcome email.
+  // Paid 1:1 consulting — our own service, so it sits above the affiliate
+  // block and is offered to consumers only (an employer posting a job is the
+  // wrong audience for cross-border tax advice).
+  const consultingHtml = isPublisher ? '' : renderConsulting(lang);
+
   const recommendedHtml = isPublisher
     ? ''
     : renderRecommendedBlock({
@@ -520,6 +609,7 @@ export function buildWelcomeEmail({
       <table width="100%" cellpadding="0" cellspacing="0">${renderQuickLinks(content.quickLinks)}</table>
     </td></tr>
     ${renderCredibility(credibilityText)}
+    ${consultingHtml}
     ${renderDeliverability(deliverabilityText)}
     ${recommendedHtml}
     ${renderFooter(lang, unsub, preferencesUrl)}

--- a/functions/src/newsletterWelcomeEmail.js
+++ b/functions/src/newsletterWelcomeEmail.js
@@ -23,7 +23,8 @@ import { isNewsletterExcluded } from './lib/emailSuppression.js';
 import { resolveWelcomeContext } from './lib/welcomeSegment.js';
 import { buildWelcomeEmail } from './lib/welcomeEmailTemplate.js';
 import { buildLifecycleEmailHeaders } from './lib/lifecycleEmailHeaders.js';
-import { makeOneClickUnsubscribeUrl, makePreferencesUrl } from './lib/newsletterUrls.js';
+import { makeOneClickUnsubscribeUrl, makePreferencesUrl, wrapAuthenticatedHrefs } from './lib/newsletterUrls.js';
+import { shouldSkipSubscriber } from './jobAlertBackfillCore.js';
 import { inferInterest, resolveDripSegment } from './lib/newsletterSegments.js';
 
 const FROM_EMAIL = 'Frontaliere Ticino <newsletter@frontaliereticino.ch>';
@@ -61,6 +62,44 @@ function toDate(value) {
 // Sentinel error used to abort the idempotency-claim transaction when a
 // concurrent caller already won the claim — never leaks past this module.
 class WelcomeAlreadySentError extends Error {}
+
+/**
+ * Whether the subscriber already receives job alerts, or is about to.
+ *
+ * Ground truth is an active doc under job_alert_subscribers/{email}/alerts.
+ * That doc is written by the backfillJobAlertOnNewsletterSignup Firestore
+ * trigger, which races this send, so an absent doc is not proof of absence —
+ * fall back to `shouldSkipSubscriber`, the very predicate the trigger uses to
+ * decide. Sharing the predicate is what stops the email and the trigger from
+ * disagreeing. Never throws: on any read error, claim nothing (false), because
+ * promising alerts that do not exist is worse than offering to create ones that
+ * already do.
+ *
+ * @param {FirebaseFirestore.Firestore} db
+ * @param {string} email normalized
+ * @param {Record<string, unknown>} data subscriber doc data
+ * @returns {Promise<boolean>}
+ */
+async function hasOrWillHaveJobAlert(db, email, data) {
+  try {
+    const snap = await db.collection('job_alert_subscribers').doc(email).collection('alerts').get();
+    if (snap && !snap.empty) {
+      const anyActive = snap.docs.some((d) => (d.data() || {}).active !== false);
+      if (anyActive) return true;
+      // Every alert explicitly deactivated = the user opted out. Respect that
+      // and do not re-offer, but do not claim they are receiving alerts either.
+      return false;
+    }
+  } catch (err) {
+    console.warn('[newsletterWelcomeEmail] job alert lookup failed:', err?.message || err);
+    return false;
+  }
+  try {
+    return shouldSkipSubscriber(email, data) === null;
+  } catch {
+    return false;
+  }
+}
 
 /** Carries the skip reason out of the idempotency transaction. */
 class WelcomeNotEligibleError extends Error {
@@ -204,14 +243,34 @@ export async function sendNewsletterWelcomeEmail({ email, locale, db: injectedDb
   const ctx = resolveWelcomeContext(data);
   const resolvedLocale = locale || data.preferred_locale || data.signup_locale || data.locale || 'it';
 
+  // Job alerts are created automatically by the backfillJobAlertOnNewsletterSignup
+  // Firestore trigger, so by the time this email lands most subscribers already
+  // have one. Telling them to "create a job alert" would ask for something already
+  // done. Prefer the alert doc as ground truth; when the trigger has not fired yet
+  // (it races this send) fall back to the SAME predicate the trigger uses, so the
+  // two can't disagree.
+  const jobAlertActive = await hasOrWillHaveJobAlert(db, normalizedEmail, data);
+
   const unsubscribeUrl = makeOneClickUnsubscribeUrl(normalizedEmail, { secret: newsletterSecret });
   const preferencesUrl = makePreferencesUrl(normalizedEmail, resolvedLocale, { secret: newsletterSecret });
 
-  const { subject, html } = buildWelcomeEmail({
+  const built = buildWelcomeEmail({
     ...ctx,
     locale: resolvedLocale,
+    jobAlertActive,
     unsubscribeUrl,
     preferencesUrl,
+  });
+  const { subject } = built;
+  // Autologin on every internal link: the recipient lands already signed in, so
+  // "refine your alerts" or "back to the job" is one click, not a login wall.
+  // The unsubscribe/preferences URLs carry their own HMAC token and are left
+  // alone by shouldWrapAuthenticatedHref's asset/host rules only insofar as they
+  // are on-site — wrapping them is harmless (extra ne/ac params) and keeps a
+  // single rule for the whole body.
+  const html = wrapAuthenticatedHrefs(built.html, normalizedEmail, {
+    secret: newsletterSecret,
+    utmCampaign: `welcome_${ctx.segment}`,
   });
 
   const campaignId = `welcome_${ctx.segment}`;

--- a/scripts/assemble-jobs-dataset.mjs
+++ b/scripts/assemble-jobs-dataset.mjs
@@ -171,6 +171,51 @@ function sanitizeJobLocationField(rawValue) {
 }
 
 /**
+ * Repair a `company` value that is actually a slice of the job DESCRIPTION.
+ *
+ * The extraction bug that produced these was fixed upstream on 2026-07-27
+ * (`looksLikeShortLabelValue` in scripts/lib/shared-jobs-crawler.mjs, #4810),
+ * but records crawled before that keep the bad value forever: a job is only
+ * rewritten when it is re-crawled, and `company` feeds the job page's
+ * structured-data `hiringOrganization.name` (AGENTS.md Non-Negotiable #3) plus
+ * the newsletter/job-alert context. This is the persist-time net that repairs
+ * them and stops the same class returning through any of the ~80 other parsers.
+ *
+ * Deliberately LOOSER than `looksLikeShortLabelValue`: that one filters a
+ * risky extraction branch and may safely reject a real name (another branch
+ * then supplies it), whereas here a false positive would discard a genuine
+ * employer. Verified against the live dataset: flags all 37 corrupted records
+ * and none of "asana Spital AG (Menziken / Leuggern)",
+ * "tl (Transports publics de la région lausannoise)" or
+ * "KSML — Kantonaler Stellenmarkt für Lehrerinnen und Lehrer (Kanton Bern)".
+ *
+ * @param {string} rawValue
+ * @param {string} [fallback] display name to use when the value is prose
+ * @returns {string} the original value, or the fallback when it was prose
+ */
+export function sanitizeJobCompanyField(rawValue, fallback = '') {
+  const s = String(rawValue ?? '').trim();
+  if (!s) return fallback || s;
+  // Control / bidi / zero-width characters never belong in an employer name.
+  if (/[\u0000-\u001F\u007F\u200B-\u200F\u202A-\u202E\u2060-\u2064\uFEFF]/.test(s)) return fallback || '';
+  // Short values are names, however oddly cased ("tl", "asana Spital AG").
+  if (s.length <= 60) return s;
+  const startsMidSentence = /^[^\p{Lu}\p{N}]/u.test(s);
+  const hasSentenceBreak = /[.;]\s+\p{Ll}/u.test(s);
+  if (startsMidSentence || hasSentenceBreak) return fallback || '';
+  return s;
+}
+
+/** "zurich-insurance-sede-ticino" → "Zurich Insurance Sede Ticino". */
+function humanizeCompanyKey(key) {
+  return String(key || '')
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/**
  * Upstream normalization applied to every crawler slice BEFORE it is written
  * to disk (the single funnel `writeJobsCrawlerSlice`). This moves location
  * hardening to write-time so corrupted `location` strings never reach the
@@ -198,6 +243,7 @@ function sanitizeJobLocationField(rawValue) {
  */
 export function normalizeParsedJobsForSlice(jobs) {
   let locationFixed = 0;
+  let companyFixed = 0;
   let localityBackfilled = 0;
   let countryDefaulted = 0;
   let regionDefaulted = 0;
@@ -209,6 +255,14 @@ export function normalizeParsedJobsForSlice(jobs) {
       if (cleaned !== job.location) {
         job.location = cleaned;
         locationFixed++;
+      }
+    }
+
+    if (typeof job.company === 'string') {
+      const cleanedCompany = sanitizeJobCompanyField(job.company, humanizeCompanyKey(job.companyKey));
+      if (cleanedCompany !== job.company) {
+        job.company = cleanedCompany;
+        companyFixed++;
       }
     }
     // Guard on .trim(): an empty/whitespace addressLocality is `typeof string`

--- a/scripts/preview-welcome-email.mjs
+++ b/scripts/preview-welcome-email.mjs
@@ -36,7 +36,7 @@ import { writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { resolveWelcomeContext } from '../functions/src/lib/welcomeSegment.js';
 import { buildWelcomeEmail } from '../functions/src/lib/welcomeEmailTemplate.js';
-import { makeUnsubscribeUrl } from '../services/newsletterUrls.mjs';
+import { makeUnsubscribeUrl, makePreferencesUrl, wrapAuthenticatedHrefs } from '../services/newsletterUrls.mjs';
 
 const WELCOME_SEGMENTS = ['job', 'salary', 'utility', 'publisher', 'general'];
 const LOCALES = ['it', 'en', 'de', 'fr'];
@@ -152,7 +152,12 @@ function syntheticDocFor(segment) {
 
 function renderOne(doc, locale) {
   const ctx = resolveWelcomeContext(doc);
-  const unsubscribeUrl = makeUnsubscribeUrl(doc.email || 'preview@example.com');
+  const email = doc.email || 'preview@example.com';
+  const unsubscribeUrl = makeUnsubscribeUrl(email);
+  // Job alerts are auto-created at signup, so the live `job` email usually takes
+  // the "already active" wording. --no-job-alert renders the other branch.
+  const jobAlertActive = !flag('no-job-alert');
+  const preferencesUrl = makePreferencesUrl(email, locale, { fallbackUnsigned: true });
   const { subject, preheader, html } = buildWelcomeEmail({
     segment: ctx.segment,
     locale,
@@ -162,10 +167,14 @@ function renderOne(doc, locale) {
     locationLabel: ctx.locationLabel,
     jobBackPath: ctx.jobBackPath,
     toolKey: ctx.toolKey,
+    jobAlertActive,
     unsubscribeUrl,
+    preferencesUrl,
     acquisitionSource: ctx.acquisitionSource,
   });
-  return { resolvedSegment: ctx.segment, subject, preheader, html };
+  // Mirror the sender: every internal link carries autologin credentials.
+  const authedHtml = wrapAuthenticatedHrefs(html, email, { utmCampaign: `welcome_${ctx.segment}` });
+  return { resolvedSegment: ctx.segment, subject, preheader, html: authedHtml };
 }
 
 async function runRenderOnly() {

--- a/scripts/send-newsletter.mjs
+++ b/scripts/send-newsletter.mjs
@@ -45,7 +45,7 @@ import { captureEmailEvent, EMAIL_EXPERIMENT_EVENTS } from '../functions/src/lib
 import { refreshEngagementScore } from '../functions/src/lib/engagementScore.js';
 import { prioritizeSubscribers } from '../services/newsletter-priority.mjs';
 import { NEWSLETTER_EXCLUDED_STATUSES } from '../services/emailSuppression.mjs';
-import { makeUnsubscribeUrl, makeResubscribeUrl, makeOneClickUnsubscribeUrl, generateAutologinCode, makePreferencesUrl } from '../services/newsletterUrls.mjs';
+import { makeUnsubscribeUrl, makeResubscribeUrl, makeOneClickUnsubscribeUrl, generateAutologinCode, makePreferencesUrl, makeAuthenticatedUrl, shouldWrapAuthenticatedHref } from '../services/newsletterUrls.mjs';
 import { filterFixtureJobs } from './lib/fixture-data-filter.mjs';
 import { isOwnerEmail, isCanaryJob } from './lib/canaryAd.mjs';
 import { getCascadeDailyCapacity, finiteDailyLimit, PROVIDERS as EMAIL_PROVIDERS } from './lib/email-cascade.mjs';
@@ -657,31 +657,12 @@ async function generateAISubject(ctx) {
 // services/newsletterUrls.mjs (shared with send-job-alerts.mjs and the
 // sunset/win-back runner so the HMAC token scheme can't drift, AGENTS.md #6).
 
-// generateAutologinCode lives in services/newsletterUrls.mjs (shared with the
-// win-back/sunset runner so the autologin HMAC scheme can't drift). Deterministic,
-// never-expiring; the client exchanges it for a fresh token via Cloud Function.
-function makeAuthenticatedUrl(targetUrl, email, autologinCode) {
-  const url = new URL(targetUrl, BASE_URL);
-  // Short param names keep total URL < 1000 chars — Mailgun silently
-  // skips click-tracking for href values ≥ 1000 characters.
-  url.searchParams.set('ne', email.toLowerCase());
-  // 'ac' = autologin code (64-char HMAC hex, never expires)
-  if (autologinCode) url.searchParams.set('ac', autologinCode);
-  // GA4 "Email" channel: utm_medium matching "newsletter" is sufficient
-  url.searchParams.set('utm_medium', 'newsletter');
-  return url.toString();
-}
-
-function shouldWrapNewsletterHref(rawHref) {
-  if (!rawHref) return false;
-  if (rawHref.startsWith('mailto:') || rawHref.startsWith('tel:') || rawHref.startsWith('#')) return false;
-  let url;
-  try { url = new URL(rawHref, BASE_URL); } catch { return false; }
-  const host = url.hostname.replace(/^www\./, '');
-  if (host !== 'frontaliereticino.ch') return false;
-  if (url.pathname.startsWith('/images/') || url.pathname.startsWith('/icons/')) return false;
-  return true;
-}
+// makeAuthenticatedUrl / shouldWrapNewsletterHref / generateAutologinCode all
+// live in services/newsletterUrls.mjs (canonical under functions/src/lib/), shared
+// with the win-back/sunset runner and the welcome email so the autologin HMAC
+// scheme and the wrapping rules can't drift. Deterministic, never-expiring; the
+// client exchanges the code for a fresh token via Cloud Function.
+const shouldWrapNewsletterHref = shouldWrapAuthenticatedHref;
 
 async function personalizeHtmlForRecipient(email, html) {
   const hrefMatches = [...html.matchAll(/href="([^"]+)"/g)];
@@ -693,7 +674,7 @@ async function personalizeHtmlForRecipient(email, html) {
   const replacements = new Map();
   const uniqueHrefs = [...new Set(hrefMatches.map((m) => m[1]).filter(shouldWrapNewsletterHref))];
   for (const href of uniqueHrefs) {
-    const wrapped = makeAuthenticatedUrl(href, email, autologinCode);
+    const wrapped = makeAuthenticatedUrl(href, email, { autologinCode });
     replacements.set(href, wrapped);
   }
 
@@ -715,7 +696,7 @@ function personalizeHtmlWithToken(email, html, autologinCode) {
   const replacements = new Map();
   const uniqueHrefs = [...new Set(hrefMatches.map((m) => m[1]).filter(shouldWrapNewsletterHref))];
   for (const href of uniqueHrefs) {
-    const wrapped = makeAuthenticatedUrl(href, email, autologinCode);
+    const wrapped = makeAuthenticatedUrl(href, email, { autologinCode });
     replacements.set(href, wrapped);
   }
 

--- a/services/newsletterUrls.mjs
+++ b/services/newsletterUrls.mjs
@@ -19,6 +19,9 @@ export {
   makeResubscribeUrl,
   generateAutologinCode,
   makeAuthenticatedActionUrl,
+  makeAuthenticatedUrl,
+  shouldWrapAuthenticatedHref,
+  wrapAuthenticatedHrefs,
   makePreferencesUrl,
   PREFERENCES_SLUG,
 } from '../functions/src/lib/newsletterUrls.js';

--- a/tests/job-company-sanitization.test.ts
+++ b/tests/job-company-sanitization.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Persist-time repair of `company` values that are a slice of the job
+ * DESCRIPTION rather than the employer name.
+ *
+ * The extraction bug was fixed upstream on 2026-07-27 (`looksLikeShortLabelValue`
+ * in scripts/lib/shared-jobs-crawler.mjs, #4810), but 37 records crawled between
+ * 2026-07-06 and 2026-07-21 kept the bad value: a job is only rewritten when it
+ * is re-crawled. `company` feeds the job page's structured-data
+ * `hiringOrganization.name` (AGENTS.md Non-Negotiable #3), so this net repairs
+ * the stale ones and closes the class for every other parser.
+ *
+ * The values below are verbatim from the live dataset.
+ */
+import { describe, expect, it } from 'vitest';
+import { sanitizeJobCompanyField, normalizeParsedJobsForSlice } from '../scripts/assemble-jobs-dataset.mjs';
+
+const CORRUPTED = [
+  'al and prioritisation skills. Customer Focus: A customer-centric mindset, always prioritising the needs of our',
+  '). Vorab erhältst du einen Überblick über Ablauf und Lernziele – so weißt du immer, was dich erwartet und was du',
+  '. Ready to make the change? If this sounds like the kind of work that would challenge you, grow you and give y',
+];
+
+// Real employers from the same dataset. A false positive here would erase a
+// genuine name from a live job page, so each is asserted individually.
+const LEGITIMATE = [
+  'EOC – Ente Ospedaliero Cantonale',
+  'A++ Group',
+  'asana Spital AG (Menziken / Leuggern)',
+  'tl (Transports publics de la région lausannoise)',
+  'KSML — Kantonaler Stellenmarkt für Lehrerinnen und Lehrer (Kanton Bern)',
+  'IKEA',
+  'SUPSI / DTI',
+  'Città di Mendrisio',
+  "McDonald's Switzerland",
+  'Ferrovia Retica (RhB)',
+];
+
+describe('sanitizeJobCompanyField', () => {
+  it.each(CORRUPTED)('replaces the description fragment %#', (value) => {
+    expect(sanitizeJobCompanyField(value, 'Zurich Insurance Sede Ticino')).toBe('Zurich Insurance Sede Ticino');
+  });
+
+  it.each(LEGITIMATE)('leaves the real employer "%s" untouched', (value) => {
+    expect(sanitizeJobCompanyField(value, 'FALLBACK')).toBe(value);
+  });
+
+  it('drops the value rather than keeping prose when no fallback is available', () => {
+    expect(sanitizeJobCompanyField(CORRUPTED[0])).toBe('');
+  });
+
+  it('rejects control, bidi and zero-width characters anywhere', () => {
+    expect(sanitizeJobCompanyField('Acme‮Corp', 'FALLBACK')).toBe('FALLBACK');
+    expect(sanitizeJobCompanyField('Acme​Corp', 'FALLBACK')).toBe('FALLBACK');
+  });
+
+  it('handles empty and non-string input without throwing', () => {
+    expect(sanitizeJobCompanyField('', 'FALLBACK')).toBe('FALLBACK');
+    expect(() => sanitizeJobCompanyField(undefined as unknown as string)).not.toThrow();
+    expect(() => sanitizeJobCompanyField(null as unknown as string)).not.toThrow();
+  });
+});
+
+describe('normalizeParsedJobsForSlice — company repair', () => {
+  it('repairs a corrupted company from the record companyKey', () => {
+    const jobs = [{
+      company: CORRUPTED[0],
+      companyKey: 'zurich-insurance-sede-ticino',
+      location: 'Zürich',
+    }];
+    normalizeParsedJobsForSlice(jobs);
+    expect(jobs[0].company).toBe('Zurich Insurance Sede Ticino');
+  });
+
+  it('leaves a healthy record alone', () => {
+    const jobs = [{ company: 'EOC – Ente Ospedaliero Cantonale', companyKey: 'eoc', location: 'Lugano' }];
+    normalizeParsedJobsForSlice(jobs);
+    expect(jobs[0].company).toBe('EOC – Ente Ospedaliero Cantonale');
+  });
+});

--- a/tests/newsletter-welcome-email.test.ts
+++ b/tests/newsletter-welcome-email.test.ts
@@ -60,7 +60,10 @@ function applyWrite(existing: Record<string, unknown> | undefined, data: Record<
   return base;
 }
 
-function createFakeDb(initialDocs: Record<string, Record<string, Record<string, unknown>>> = {}) {
+function createFakeDb(
+  initialDocs: Record<string, Record<string, Record<string, unknown>>> = {},
+  initialSubDocs: Record<string, Array<Record<string, unknown>>> = {},
+) {
   // initialDocs is keyed per-collection-then-id (e.g. { newsletter_subscribers:
   // { 'user@example.com': {...} } }) for call-site readability; flatten it to
   // the same `${collection}/${id}` keys makeDocRef()/get()/set() operate on.
@@ -71,6 +74,9 @@ function createFakeDb(initialDocs: Record<string, Record<string, Record<string, 
     }
   }
   const events: Array<{ collection: string; data: Record<string, unknown> }> = [];
+  // Sub-collection rows keyed `${collection}/${id}/${subName}`, e.g. the
+  // job_alert_subscribers alerts the welcome copy branches on.
+  const subDocs: Record<string, Array<Record<string, unknown>>> = initialSubDocs;
   let chain: Promise<unknown> = Promise.resolve();
 
   function makeDocRef(name: string, id: string) {
@@ -83,6 +89,19 @@ function createFakeDb(initialDocs: Record<string, Record<string, Record<string, 
       collection: (subName: string) => ({
         add: async (data: Record<string, unknown>) => {
           events.push({ collection: `${key}/${subName}`, data });
+        },
+        // Subcollections must support get(), not just add(): the sender reads
+        // job_alert_subscribers/{email}/alerts to decide whether the welcome
+        // confirms existing alerts or offers to create them. Without this the
+        // read throws, the sender's catch swallows it, and the whole
+        // alert-aware branch silently tests as "no alerts".
+        get: async () => {
+          const rows = subDocs[`${key}/${subName}`] || [];
+          return {
+            empty: rows.length === 0,
+            size: rows.length,
+            docs: rows.map((d) => ({ data: () => d })),
+          };
         },
       }),
     };
@@ -547,5 +566,71 @@ describe('handleSubscriptionManagement — confirm action fires the welcome emai
     sendEmailCascadeMock.mockClear();
     await handleSubscriptionManagement({ action: 'confirm', email, token, secret, locale: 'it', db });
     expect(sendEmailCascadeMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── Job-alert awareness ──────────────────────────────────────────
+// Alerts are auto-created at signup by the backfillJobAlertOnNewsletterSignup
+// trigger, so the welcome must confirm them rather than ask for something
+// already done. These tests exercise the real lookup — before the fake db
+// grew subcollection get(), the read threw, the sender's catch swallowed it,
+// and this whole branch silently tested as "no alerts".
+describe('sendNewsletterWelcomeEmail — job alert awareness', () => {
+  const EMAIL = 'jobseeker@example.com';
+  const ALERTS_KEY = `job_alert_subscribers/${EMAIL}/alerts`;
+
+  // A doc carrying a job signal: this is what makes the trigger create an alert.
+  function jobDoc(overrides: Record<string, unknown> = {}) {
+    return recentDoc({ sector_interest: 'health', job_location: 'Lugano', job_company: 'EOC – Ente Ospedaliero Cantonale', ...overrides });
+  }
+
+  async function sentHtml() {
+    const call = sendEmailCascadeMock.mock.calls.at(-1)?.[0] as Array<{ payload: { html: string; subject: string } }>;
+    return call[0].payload;
+  }
+
+  it('confirms alerts when an active alert doc exists', async () => {
+    const { sendNewsletterWelcomeEmail } = await import('../functions/src/newsletterWelcomeEmail.js');
+    const db = createFakeDb(
+      { newsletter_subscribers: { [EMAIL]: jobDoc() } },
+      { [ALERTS_KEY]: [{ active: true, keywords: ['infermiere'] }] },
+    );
+    const result = await sendNewsletterWelcomeEmail({ email: EMAIL, locale: 'it', db, trigger: 'confirm' });
+    expect(result.success).toBe(true);
+    const { subject, html } = await sentHtml();
+    expect(subject).toBe('Sei dentro: gli avvisi lavoro sono attivi');
+    expect(html).not.toContain('Crea il tuo job alert');
+  });
+
+  it('offers to create when every alert was explicitly deactivated', async () => {
+    // deleteAlert sets active:false — an explicit opt-out we must not override
+    // by claiming their alerts are running.
+    const { sendNewsletterWelcomeEmail } = await import('../functions/src/newsletterWelcomeEmail.js');
+    const db = createFakeDb(
+      { newsletter_subscribers: { [EMAIL]: jobDoc() } },
+      { [ALERTS_KEY]: [{ active: false }] },
+    );
+    await sendNewsletterWelcomeEmail({ email: EMAIL, locale: 'it', db, trigger: 'confirm' });
+    const { subject } = await sentHtml();
+    expect(subject).not.toBe('Sei dentro: gli avvisi lavoro sono attivi');
+  });
+
+  it('falls back to the trigger predicate when the alert doc has not been written yet', async () => {
+    // The trigger races this send. A signal-bearing subscriber WILL get an
+    // alert, so the copy may confirm it even before the doc lands.
+    const { sendNewsletterWelcomeEmail } = await import('../functions/src/newsletterWelcomeEmail.js');
+    const db = createFakeDb({ newsletter_subscribers: { [EMAIL]: jobDoc() } }, {});
+    await sendNewsletterWelcomeEmail({ email: EMAIL, locale: 'it', db, trigger: 'confirm' });
+    const { subject } = await sentHtml();
+    expect(subject).toBe('Sei dentro: gli avvisi lavoro sono attivi');
+  });
+
+  it('does not claim alerts for a subscriber with no job signal at all', async () => {
+    const { sendNewsletterWelcomeEmail } = await import('../functions/src/newsletterWelcomeEmail.js');
+    const db = createFakeDb({ newsletter_subscribers: { 'plain@example.com': recentDoc() } }, {});
+    const result = await sendNewsletterWelcomeEmail({ email: 'plain@example.com', locale: 'it', db, trigger: 'confirm' });
+    expect(result.success).toBe(true);
+    const { subject } = await sentHtml();
+    expect(subject).not.toBe('Sei dentro: gli avvisi lavoro sono attivi');
   });
 });

--- a/tests/route-slugs-no-drift.test.ts
+++ b/tests/route-slugs-no-drift.test.ts
@@ -97,4 +97,20 @@ describe('route-slugs anti-drift guard (#4315)', () => {
       expect(PREFERENCES_SLUG[locale]).toBe(SLUG_TABLES[locale].newsletterPreferences);
     }
   });
+
+  // Same forced-copy situation for the consulting route: the welcome email
+  // promotes the paid 1:1 consultation, so functions/src/lib/newsletterUrlPaths.js
+  // carries the per-locale path. router.ts builds it as `${prefix}/${table.consulting}`,
+  // so the map entry must equal that, trailing-slash aside.
+  it('functions/src/lib/newsletterUrlPaths.js consulting paths stay in sync with SLUG_TABLES.*.consulting', async () => {
+    const { LOCALE_PATH_MAP } = await import('../functions/src/lib/newsletterUrlPaths.js');
+    const variants = LOCALE_PATH_MAP['/consulenza'];
+    expect(variants).toBeTruthy();
+    for (const locale of ['it', 'en', 'de', 'fr'] as const) {
+      const expected = locale === 'it'
+        ? `/${SLUG_TABLES.it.consulting}`
+        : `/${locale}/${SLUG_TABLES[locale].consulting}`;
+      expect(variants[locale]).toBe(expected);
+    }
+  });
 });

--- a/tests/welcome-email-followups.test.ts
+++ b/tests/welcome-email-followups.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Welcome email — behaviours added after the first live run.
+ *
+ * Guards:
+ *  - job alerts are auto-created at signup by the backfillJobAlertOnNewsletterSignup
+ *    trigger, so the `job` segment must CONFIRM them rather than ask the reader to
+ *    create what already exists — and must fall back to the create wording when
+ *    there is no preferences URL to send them to;
+ *  - the paid consulting block renders, localized, for consumers and never for
+ *    the publisher (employer) audience;
+ *  - every internal link carries autologin credentials so the recipient lands
+ *    signed in, without breaking the signed unsubscribe token or exceeding
+ *    Mailgun's 1000-character click-tracking limit.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildWelcomeEmail } from '../functions/src/lib/welcomeEmailTemplate.js';
+import {
+  makeOneClickUnsubscribeUrl,
+  makePreferencesUrl,
+  wrapAuthenticatedHrefs,
+  shouldWrapAuthenticatedHref,
+} from '../functions/src/lib/newsletterUrls.js';
+
+const LOCALES = ['it', 'en', 'de', 'fr'] as const;
+const SECRET = 'test-secret-for-welcome-followups';
+const EMAIL = 'mario.rossi@example.com';
+
+function jobEmail(locale: string, jobAlertActive: boolean, preferencesUrl: string | null = 'https://frontaliereticino.ch/preferenze-newsletter?email=x&token=y') {
+  return buildWelcomeEmail({
+    segment: 'job',
+    locale,
+    firstName: 'Marco',
+    company: 'EOC – Ente Ospedaliero Cantonale',
+    sectorKey: 'health',
+    locationLabel: 'Lugano',
+    jobBackPath: '/cerca-lavoro-ticino/infermiere-eoc/',
+    jobAlertActive,
+    unsubscribeUrl: 'https://frontaliereticino.ch/disiscrivi-newsletter/?action=unsubscribe&email=x&token=y',
+    preferencesUrl,
+  });
+}
+
+function visibleText(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/g, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;|&#847;|&zwnj;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+describe('welcome email — job alert already active', () => {
+  it.each(LOCALES)('[%s] confirms existing alerts instead of asking to create them', (locale) => {
+    const active = jobEmail(locale, true);
+    const inactive = jobEmail(locale, false);
+
+    // The two variants must genuinely differ — subject, heading and CTA all move.
+    expect(active.subject).not.toBe(inactive.subject);
+    expect(active.preheader).not.toBe(inactive.preheader);
+    expect(visibleText(active.html)).not.toBe(visibleText(inactive.html));
+
+    // The create-an-alert imperative must be gone from the active variant.
+    const activeText = visibleText(active.html).toLowerCase();
+    for (const imperative of ['crea un job alert', 'set up a job alert', 'richte einen job-alert', 'crée une alerte']) {
+      expect(activeText).not.toContain(imperative);
+    }
+  });
+
+  it.each(LOCALES)('[%s] active-variant CTA points at the preferences page, not the job board', (locale) => {
+    const prefs = makePreferencesUrl(EMAIL, locale, { secret: SECRET });
+    const active = buildWelcomeEmail({
+      segment: 'job', locale, jobAlertActive: true,
+      sectorKey: 'health', locationLabel: 'Lugano',
+      unsubscribeUrl: 'https://frontaliereticino.ch/?action=unsubscribe',
+      preferencesUrl: prefs,
+    });
+    expect(active.html).toContain(prefs.replace(/&/g, '&amp;'));
+  });
+
+  it.each(LOCALES)('[%s] falls back to the create wording when there is no preferences URL', (locale) => {
+    // No signing secret → no preferences URL → the "refine your alerts" button
+    // would be dead, so the copy must revert rather than emit a broken CTA.
+    // Compare against the inactive variant built under the SAME conditions, so
+    // the only thing that could differ is the alert wording itself.
+    const degraded = jobEmail(locale, true, null);
+    const inactive = jobEmail(locale, false, null);
+    expect(degraded.subject).toBe(inactive.subject);
+    expect(degraded.preheader).toBe(inactive.preheader);
+    expect(visibleText(degraded.html)).toBe(visibleText(inactive.html));
+  });
+
+  it('subjects stay within the 60-character budget in every locale', () => {
+    for (const locale of LOCALES) {
+      expect(jobEmail(locale, true).subject.length).toBeLessThanOrEqual(60);
+    }
+  });
+});
+
+describe('welcome email — consulting block', () => {
+  const CONSULTING_PATH: Record<string, string> = {
+    it: '/consulenza/',
+    en: '/en/consulting/',
+    de: '/de/beratung/',
+    fr: '/fr/consultation/',
+  };
+
+  it.each(LOCALES)('[%s] renders with the locale-correct, trailing-slashed consulting link', (locale) => {
+    const { html } = jobEmail(locale, true);
+    expect(html).toContain(`https://frontaliereticino.ch${CONSULTING_PATH[locale]}`);
+  });
+
+  it.each(LOCALES)('[%s] carries real localized copy, not the Italian fallback', (locale) => {
+    const text = visibleText(jobEmail(locale, true).html);
+    const marker: Record<string, string> = {
+      it: 'Doppia imposizione',
+      en: 'Double taxation',
+      de: 'Doppelbesteuerung',
+      fr: 'Double imposition',
+    };
+    expect(text).toContain(marker[locale]);
+    if (locale !== 'it') expect(text).not.toContain(marker.it);
+  });
+
+  it.each(LOCALES)('[%s] is absent for the publisher audience', (locale) => {
+    const { html } = buildWelcomeEmail({
+      segment: 'publisher', locale,
+      unsubscribeUrl: 'https://frontaliereticino.ch/?action=unsubscribe',
+    });
+    expect(html).not.toContain(CONSULTING_PATH[locale]);
+  });
+
+  it.each(['salary', 'utility', 'general'])('is present for consumer segment "%s"', (segment) => {
+    const { html } = buildWelcomeEmail({
+      segment, locale: 'it',
+      unsubscribeUrl: 'https://frontaliereticino.ch/?action=unsubscribe',
+    });
+    expect(html).toContain('https://frontaliereticino.ch/consulenza/');
+  });
+});
+
+describe('welcome email — autologin links', () => {
+  it('wraps every internal href with ne/ac and leaves external hosts alone', () => {
+    const { html } = jobEmail('it', true, makePreferencesUrl(EMAIL, 'it', { secret: SECRET }));
+    const wrapped = wrapAuthenticatedHrefs(html, EMAIL, { secret: SECRET, utmCampaign: 'welcome_job' });
+    const hrefs = [...wrapped.matchAll(/href="([^"]+)"/g)].map((m) => m[1].replace(/&amp;/g, '&'));
+
+    expect(hrefs.length).toBeGreaterThan(0);
+    for (const href of hrefs) {
+      if (!shouldWrapAuthenticatedHref(href)) continue;
+      expect(href).toContain('ne=');
+      expect(href).toContain('ac=');
+      expect(href).toContain('utm_campaign=welcome_job');
+    }
+  });
+
+  it('keeps every link under Mailgun\'s 1000-character click-tracking limit', () => {
+    const { html } = jobEmail('it', true, makePreferencesUrl(EMAIL, 'it', { secret: SECRET }));
+    const wrapped = wrapAuthenticatedHrefs(html, EMAIL, { secret: SECRET, utmCampaign: 'welcome_job' });
+    for (const [, href] of wrapped.matchAll(/href="([^"]+)"/g)) {
+      expect(href.replace(/&amp;/g, '&').length).toBeLessThan(1000);
+    }
+  });
+
+  it('preserves the signed unsubscribe token through wrapping', () => {
+    const unsubscribeUrl = makeOneClickUnsubscribeUrl(EMAIL, { secret: SECRET });
+    const tokenMatch = unsubscribeUrl.match(/token=([a-f0-9]{64})/);
+    expect(tokenMatch).not.toBeNull();
+
+    const { html } = buildWelcomeEmail({
+      segment: 'job', locale: 'it', jobAlertActive: false, unsubscribeUrl,
+    });
+    const wrapped = wrapAuthenticatedHrefs(html, EMAIL, { secret: SECRET });
+    expect(wrapped).toContain(tokenMatch![1]);
+  });
+
+  it('never rewrites a third-party href', () => {
+    const html = '<a href="https://wise.com/invite/abc">Wise</a><a href="mailto:x@y.it">mail</a>';
+    expect(wrapAuthenticatedHrefs(html, EMAIL, { secret: SECRET })).toBe(html);
+  });
+
+  it('is a no-op without an email, rather than emitting half-formed links', () => {
+    const html = '<a href="https://frontaliereticino.ch/calcola-stipendio/">x</a>';
+    expect(wrapAuthenticatedHrefs(html, '', { secret: SECRET })).toBe(html);
+  });
+});


### PR DESCRIPTION
Quattro follow-up sulla welcome email live, più la riparazione del difetto sui dati che aveva motivato il layer di sanitizzazione.

## Implementato

**Gli avvisi lavoro sono già attivi — la copy ora lo dice**
- `backfillJobAlertOnNewsletterSignup` è un trigger Firestore che crea l'alert automaticamente all'iscrizione. Chiedere "crea il tuo job alert" domandava una cosa già fatta, alla maggioranza dei destinatari (l'83% si iscrive dentro una pagina offerta, quindi ha il segnale che rende idonei).
- Il sender risolve lo stato reale: il doc dell'alert come verità, e — quando il trigger non ha ancora girato, perché corre insieme all'invio — ripiega sullo **stesso predicato `shouldSkipSubscriber` che usa il trigger**, così i due non possono dissentire. Su errore di lettura non promette nulla.
- Il segmento `job` ha ora oggetto, preheader, titolo e CTA dedicati per la variante "avvisi attivi", in tutti e 4 i locali; la CTA porta alla pagina preferenze per affinarli invece che al job board.
- Senza URL preferenze (secret assente) la copy **torna alla versione "crea"** invece di spedire un pulsante morto.

**Link di autologin**
- Ogni link interno porta `ne`/`ac`: il destinatario atterra già autenticato, non su un muro di login.
- Le regole di wrapping e il builder erano copie private di `send-newsletter.mjs`: ora vivono una volta sola nel modulo canonico e la newsletter le importa. Una sola definizione dello schema autologin.
- Verificato sul reso: 20/20 email con autologin, nessun link ≥1000 caratteri (limite oltre il quale Mailgun smette di tracciare i click), token di disiscrizione firmato intatto attraverso il wrapping, host esterni non toccati.

**Blocco consulenza**
- Promuove la consulenza 1:1 a pagamento, localizzato, sopra il blocco affiliato e solo verso i consumatori — un datore di lavoro che pubblica un annuncio è il pubblico sbagliato per la consulenza fiscale da frontaliere.
- I 4 URL sono stati verificati **live**: `/consulenza/`, `/en/consulting/`, `/de/beratung/`, `/fr/consultation/` rispondono tutti 200.
- Il path per-locale sta in `newsletterUrlPaths.js` perché una Cloud Function non può importare la tabella TypeScript delle route; un test di drift asserisce che i due coincidano.

**Riparazione della corruzione di `company`**
- Ho cercato la causa a monte e **era già stata corretta**: `looksLikeShortLabelValue` è entrata il 2026-07-27 (#4810) e blocca tutti e tre i valori corrotti reali. I 37 record sporchi sono stati crawlati fra il 6 e il 21 luglio, cioè **prima** della guardia, e un job viene riscritto solo quando è ri-crawlato: restano lì.
- Siccome `company` alimenta `hiringOrganization.name` dello structured data (Non-Negotiable #3), aggiungo una riparazione al persist accanto a quella già esistente per `location`, con fallback sulla `companyKey` del record stesso. Vale per tutti gli ~80 parser, non solo per quello che ha causato il problema.
- È **volutamente più permissiva** del filtro a monte: lì un falso positivo è innocuo (un altro ramo fornisce il nome), qui cancellerebbe un datore di lavoro vero. Verificata sul dataset live: segnala tutti e 37 i corrotti e lascia intatti `asana Spital AG (Menziken / Leuggern)`, `tl (Transports publics de la région lausannoise)`, `KSML — Kantonaler Stellenmarkt für Lehrerinnen und Lehrer (Kanton Bern)` e ogni altro nome legittimo.

**Copertura del ramo alert-aware (aggiunto dopo l'apertura della PR)**
- Il sender legge `job_alert_subscribers/{email}/alerts`, ma il test double implementava solo `add()` sulle subcollection: la lettura lanciava, il `catch` del sender la inghiottiva, e tutti i test passavano **con il ramo inerte**. È il modo di fallire in cui la fault-tolerance nasconde una feature che non gira mai.
- Il fake Firestore ora ha una `get()` funzionante e coprono i 4 stati reali: alert attivo, alert disattivati esplicitamente dall'utente (`deleteAlert` mette `active:false` — non va scavalcato dicendogli che gli avvisi girano), doc non ancora scritto perché il trigger corre insieme all'invio, e iscritto senza alcun segnale job.
- Verificato non vacuo: stubbando il rilevamento a `false`, due test falliscono.

## Non implementato (ancora)

Nessuno.

## Test plan

- [x] Suite completa: 138.940 test verdi
- [x] Test del ramo alert-aware provati non vacui (2 rossi con rilevamento stubbato a false)
- [x] 3 nuovi file di test (70 asserzioni): copy alert-aware, blocco consulenza, autologin, sanitizzazione company
- [x] Sanitizzatore verificato eseguendo il modulo: 3 corrotti reali → fallback, 10 nomi reali legittimi → invariati (11/11)
- [x] URL consulenza verificati live nei 4 locali (HTTP 200)
- [x] Autologin verificato sul reso: 20/20 file, 0 link ≥1000 char, token unsubscribe preservato
- [x] Boundary di deploy: nessun import esce da `functions/`
- [ ] Post-merge: prima welcome reale con avvisi attivi osservata su un iscritto nuovo

## Note

**Sul worktree orfano `wt-4544-fiscal-data-accuracy/`**: avevo suggerito di rimuoverlo. Verificato meglio, **non va toccato** — contiene 5 file modificati e non committati (`build-plugins/fiscalMunicipalityData.ts`, `data/fiscal-municipalities.json`, `scripts/build-fiscal-municipalities.mjs` e altri), 0 commit ahead, e l'issue #4544 è tuttora aperta. Rimuoverlo distruggerebbe lavoro non salvato.

**Effetto collaterale evitato**: la prima stesura del sanitizzatore conteneva caratteri di controllo *letterali* nella classe regex, il che faceva trattare `scripts/assemble-jobs-dataset.mjs` come file binario da `grep` — rompendo silenziosamente tutto il tooling del repo che ci si basa. Sostituiti con escape `\uXXXX`.

Il pre-push sibling check segnala gli stessi 261 candidati euristici della PR precedente (token condivisi su codice già centralizzato: `SLUG_TABLES`, `emailCascade`, costanti colore del brand, idiomi JS). Le due duplicazioni reali che conteneva sono state chiuse in #4910; questa PR ne chiude una terza (`makeAuthenticatedUrl`/`shouldWrapNewsletterHref`, prima privati di `send-newsletter.mjs`).

**Correzione**: avevo scritto che non ne restavano altre. Non è esatto — il reviewer ha giustamente segnalato che `scripts/send-job-alerts.mjs:486` ha ancora la propria `makeAuthenticatedUrl` privata (firma diversa, `utm_medium` proprio). È una quarta duplicazione reale della stessa classe e va consolidata; la chiudo in una PR concatenata insieme alla lettura Firestore superflua segnalata sotto, non la lascio come affermazione smentita.
