### PR TITLE
chore(ci): correct the sampling comment in post-deploy-validate-dist

### DIFF
--- a/.github/workflows/post-deploy-validate-dist.yml
+++ b/.github/workflows/post-deploy-validate-dist.yml
@@ -796,8 +796,18 @@ jobs:
           # catches accidental side-effects during future audit migrations.
           AUDIT_STRICT: '1'
           # Rotating sample (scripts/lib/audit-runner.mjs's sampleFiles(),
-          # only read by `npm run audit:all` below — every other gate in this
-          # step ignores these two vars and keeps scanning 100%). audit:all's
+          # read via resolveSamplingEnv() by `npm run audit:all` below plus
+          # audit:hreflang and audit:canonical-trailing-slash — the two
+          # full-dist walkers that were this pool's critical path on run
+          # 30376520728, at 2000s and 1711s of a 58m55s job (PR #4903). Every
+          # other gate in this step still ignores these two vars and scans
+          # 100%. audit:hreflang samples only which pages it PARSES: its
+          # target-existence index is always built from the full walk, so a
+          # sampled run reports a broken alternate with the same certainty as
+          # a full one. audit:canonical-trailing-slash is 0-tolerance with no
+          # baseline to ratchet, so sampling costs at most a one-run delay on
+          # an isolated offender — a systemic regression lands in every
+          # bucket. audit:all's
           # walk+collect over the full dist/ corpus (~3.3M pages) is this
           # job's dominant cost (~54min of the ~71min job wall time, run
           # 29883145419) — the walk itself (~3.5min) is cheap; the per-file


### PR DESCRIPTION
Closes the workflow-comment item left open in #4903.

## Implementato

- `post-deploy-validate-dist.yml`: the step comment said every gate but `audit:all` ignores `AUDIT_SAMPLE_RATE` / `AUDIT_SAMPLE_SALT`. #4903 made that false for `audit:hreflang` and `audit:canonical-trailing-slash`, which now read them via `resolveSamplingEnv()`. The comment also now records why sampling those two costs no coverage.

Comment-only: no key, value or behaviour changes. `yaml.safe_load` parses the file clean.

This was written as part of #4903 and pulled back out of it: PRs from that branch were receiving zero check-runs, and a `.github/workflows` edit was the one unusual thing in the diff. That turned out not to be the cause — #4921 later carried a non-workflow diff and its checks fired normally — so it lands here on its own.

## Non implementato (ancora)

- Nessuno.
