### PR TITLE
refactor(email): consolida l'ultima copia di makeAuthenticatedUrl e salta una lettura inutile

### DIFF
--- a/functions/src/lib/newsletterUrls.js
+++ b/functions/src/lib/newsletterUrls.js
@@ -154,12 +154,22 @@ export function shouldWrapAuthenticatedHref(rawHref) {
  * @param {{secret?: string, autologinCode?: string|null, utmCampaign?: string|null}} [opts]
  * @returns {string}
  */
-export function makeAuthenticatedUrl(targetUrl, email, { secret, autologinCode, utmCampaign } = {}) {
+export function makeAuthenticatedUrl(
+  targetUrl,
+  email,
+  { secret, autologinCode, utmCampaign, utmMedium = 'newsletter', preserveExistingUtmMedium = false } = {},
+) {
   const url = new URL(targetUrl, BASE_URL);
   const code = autologinCode === undefined ? generateAutologinCode(email, { secret }) : autologinCode;
   url.searchParams.set('ne', String(email || '').toLowerCase());
   if (code) url.searchParams.set('ac', code);
-  url.searchParams.set('utm_medium', 'newsletter');
+  // Job alerts build their links from a utmBase that already carries a
+  // utm_medium; overwriting it would lose that attribution. The newsletter and
+  // the welcome email have no such base and always want the GA4 Email channel
+  // value, so overwrite stays the default.
+  if (!(preserveExistingUtmMedium && url.searchParams.has('utm_medium'))) {
+    url.searchParams.set('utm_medium', utmMedium);
+  }
   if (utmCampaign) url.searchParams.set('utm_campaign', utmCampaign);
   return url.toString();
 }

--- a/functions/src/lib/welcomeSegment.js
+++ b/functions/src/lib/welcomeSegment.js
@@ -300,6 +300,14 @@ export function normalizeSector(raw) {
     const wordCount = trimmed.split(/\s+/).filter(Boolean).length;
     if (wordCount > 8) return null;
     const key = normalizeSectorKey(trimmed);
+    // Idempotence: an already-canonical key must map to itself. Five of them
+    // (health, industry, education, construction, transport) only ever appear
+    // as human labels today ("Sanita / Ospedali"), so nothing in production
+    // feeds them back in — but a reader reasonably assumes normalize(normalize(x))
+    // === normalize(x), and the day a writer stores the canonical key those
+    // sectors would silently resolve to null and demote the reader from the
+    // `job` segment to `general`.
+    if (SECTOR_KEYS.includes(key)) return key;
     if (SECTOR_EXACT_MAP.has(key)) return SECTOR_EXACT_MAP.get(key);
     for (const [sectorKey, patterns] of SECTOR_KEYWORD_BUCKETS) {
       if (patterns.some((re) => re.test(key))) return sectorKey;

--- a/functions/src/newsletterWelcomeEmail.js
+++ b/functions/src/newsletterWelcomeEmail.js
@@ -249,7 +249,12 @@ export async function sendNewsletterWelcomeEmail({ email, locale, db: injectedDb
   // done. Prefer the alert doc as ground truth; when the trigger has not fired yet
   // (it races this send) fall back to the SAME predicate the trigger uses, so the
   // two can't disagree.
-  const jobAlertActive = await hasOrWillHaveJobAlert(db, normalizedEmail, data);
+  // Only the `job` segment branches on this, so the sub-collection read is
+  // skipped for the other four — no point paying a Firestore round-trip per
+  // send for a value nothing downstream reads.
+  const jobAlertActive = ctx.segment === 'job'
+    ? await hasOrWillHaveJobAlert(db, normalizedEmail, data)
+    : false;
 
   const unsubscribeUrl = makeOneClickUnsubscribeUrl(normalizedEmail, { secret: newsletterSecret });
   const preferencesUrl = makePreferencesUrl(normalizedEmail, resolvedLocale, { secret: newsletterSecret });

--- a/scripts/send-job-alerts.mjs
+++ b/scripts/send-job-alerts.mjs
@@ -45,7 +45,7 @@ import { runWithConcurrency, checkPageBodyLive } from './lib/live-link-check.mjs
 import { computeScheduledSendAt, resolveEffectivePreferredHour, perUserSendTimeEnabled, logScheduleDistribution } from './lib/send-schedule.mjs';
 import { resolveEffectiveJobAlertTier, JOB_ALERT_ENGAGEMENT_TIERS } from './lib/jobAlertEngagementTier.mjs';
 import { buildDeliveryDocId } from '../functions/src/lib/deliveryDocId.js';
-import { makePreferencesUrl, generateAutologinCode } from '../services/newsletterUrls.mjs';
+import { makePreferencesUrl, generateAutologinCode, makeAuthenticatedUrl as makeAuthenticatedUrlShared } from '../services/newsletterUrls.mjs';
 // localePathPrefix aliased to the local name this script has always used for
 // its locale-aware URL construction — the implementation is the canonical
 // shared helper (also used by send-newsletter.mjs, send-saved-jobs-digest.mjs).
@@ -483,16 +483,17 @@ function makeAllAlertsUnsubscribeUrl(email) {
 // generateAutologinCode lives in services/newsletterUrls.mjs (shared with
 // send-newsletter.mjs and the win-back/sunset runner, AGENTS.md #6).
 
-function makeAuthenticatedUrl(targetUrl, email, autologinCode, utmMedium = 'email') {
-  const url = new URL(targetUrl, BASE_URL);
-  url.searchParams.set('ne', email.toLowerCase());
-  if (autologinCode) url.searchParams.set('ac', autologinCode);
-  // Preserve utm_medium if caller already set it on the URL (e.g. utmBase).
-  // Default switched from 'job_alert' (which duplicated utm_source) to 'email'
-  // — analytics convention is utm_medium=channel, utm_source=identifier.
-  if (!url.searchParams.has('utm_medium')) url.searchParams.set('utm_medium', utmMedium);
-  return url.toString();
-}
+// makeAuthenticatedUrl is the shared builder in services/newsletterUrls.mjs
+// (canonical under functions/src/lib/) — same autologin scheme as the weekly
+// newsletter and the welcome email. Job alerts keep their own defaults:
+// utm_medium 'email' (analytics convention is medium=channel,
+// source=identifier) and preserve a utm_medium already set by utmBase.
+const makeAuthenticatedUrl = (targetUrl, email, autologinCode, utmMedium = 'email') =>
+  makeAuthenticatedUrlShared(targetUrl, email, {
+    autologinCode,
+    utmMedium,
+    preserveExistingUtmMedium: true,
+  });
 
 // ── Firebase Admin SDK (lazy init) ───────────────────────────
 

--- a/tests/newsletter-welcome-email.test.ts
+++ b/tests/newsletter-welcome-email.test.ts
@@ -77,6 +77,8 @@ function createFakeDb(
   // Sub-collection rows keyed `${collection}/${id}/${subName}`, e.g. the
   // job_alert_subscribers alerts the welcome copy branches on.
   const subDocs: Record<string, Array<Record<string, unknown>>> = initialSubDocs;
+  // Every sub-collection get(), so a test can assert a read did NOT happen.
+  const subCollectionGets: string[] = [];
   let chain: Promise<unknown> = Promise.resolve();
 
   function makeDocRef(name: string, id: string) {
@@ -96,6 +98,7 @@ function createFakeDb(
         // read throws, the sender's catch swallows it, and the whole
         // alert-aware branch silently tests as "no alerts".
         get: async () => {
+          subCollectionGets.push(`${key}/${subName}`);
           const rows = subDocs[`${key}/${subName}`] || [];
           return {
             empty: rows.length === 0,
@@ -110,6 +113,7 @@ function createFakeDb(
   return {
     docs,
     events,
+    subCollectionGets,
     collection: (name: string) => ({ doc: (id: string) => makeDocRef(name, id) }),
     runTransaction: (fn: (tx: { get: (ref: ReturnType<typeof makeDocRef>) => Promise<unknown>; set: (ref: ReturnType<typeof makeDocRef>, data: Record<string, unknown>, opts?: { merge?: boolean }) => void }) => Promise<unknown>) => {
       const run = chain.then(() =>
@@ -632,5 +636,30 @@ describe('sendNewsletterWelcomeEmail — job alert awareness', () => {
     expect(result.success).toBe(true);
     const { subject } = await sentHtml();
     expect(subject).not.toBe('Sei dentro: gli avvisi lavoro sono attivi');
+  });
+});
+
+// Only the `job` segment consumes jobAlertActive, so the other four must not
+// pay a Firestore sub-collection round-trip per send for a value nothing reads.
+describe('sendNewsletterWelcomeEmail — no wasted alert lookup', () => {
+  it('reads the alerts sub-collection for the job segment', async () => {
+    const { sendNewsletterWelcomeEmail } = await import('../functions/src/newsletterWelcomeEmail.js');
+    const db = createFakeDb(
+      { newsletter_subscribers: { 'j@example.com': recentDoc({ sector_interest: 'health', job_location: 'Lugano' }) } },
+      {},
+    );
+    await sendNewsletterWelcomeEmail({ email: 'j@example.com', locale: 'it', db, trigger: 'confirm' });
+    expect(db.subCollectionGets.some((k) => k.includes('job_alert_subscribers'))).toBe(true);
+  });
+
+  it('does not read it for a non-job segment', async () => {
+    const { sendNewsletterWelcomeEmail } = await import('../functions/src/newsletterWelcomeEmail.js');
+    const db = createFakeDb(
+      { newsletter_subscribers: { 'p@example.com': recentDoc({ source_cta: 'publisher_gate_email' }) } },
+      {},
+    );
+    const result = await sendNewsletterWelcomeEmail({ email: 'p@example.com', locale: 'it', db, trigger: 'confirm' });
+    expect(result.segment).toBe('publisher');
+    expect(db.subCollectionGets.some((k) => k.includes('job_alert_subscribers'))).toBe(false);
   });
 });

--- a/tests/route-slugs-no-drift.test.ts
+++ b/tests/route-slugs-no-drift.test.ts
@@ -55,6 +55,19 @@ describe('route-slugs anti-drift guard (#4315)', () => {
   // builder now live once in functions/src/lib/newsletterUrls.js (guarded
   // against SLUG_TABLES drift by the test below) and are imported here via
   // services/newsletterUrls.mjs instead of hand-copied.
+  // The autologin URL builder was privately reimplemented three times
+  // (send-newsletter.mjs, send-job-alerts.mjs, and the welcome email) before
+  // being centralized. Guard against a fourth: the senders must import it, not
+  // define their own `function makeAuthenticatedUrl`.
+  it.each(['scripts/send-newsletter.mjs', 'scripts/send-job-alerts.mjs'])(
+    '%s uses the shared makeAuthenticatedUrl instead of a private copy',
+    (file) => {
+      const src = read(file);
+      expect(src).toMatch(/from '\.\.\/services\/newsletterUrls\.mjs'/);
+      expect(src).not.toMatch(/^function makeAuthenticatedUrl\s*\(/m);
+    },
+  );
+
   it.each(['scripts/send-newsletter.mjs', 'scripts/send-job-alerts.mjs'])(
     '%s imports makePreferencesUrl from the shared builder instead of hand-copying a slug table',
     (file) => {

--- a/tests/welcome-segment.test.ts
+++ b/tests/welcome-segment.test.ts
@@ -478,4 +478,14 @@ describe('resolveWelcomeContext — never throws, always sane', () => {
       expect(value).toBeNull();
     }
   });
+
+  // Idempotence: normalize(normalize(x)) === normalize(x). Five canonical keys
+  // used to return null when fed back in, which would demote a subscriber from
+  // the `job` segment to `general` the day a writer stored the canonical value.
+  it.each(['health', 'admin', 'retail', 'hospitality', 'logistics', 'finance', 'tech', 'industry', 'education', 'construction', 'transport', 'cleaning', 'other'])(
+    'normalizeSector is idempotent for the canonical key "%s"',
+    (key) => {
+      expect(normalizeSector(key)).toBe(key);
+    },
+  );
 });


### PR DESCRIPTION
Chiude i due punti azionabili della review di #4923, più una cosa emersa scrivendo i test.

## Implementato

**La quarta copia di `makeAuthenticatedUrl`**
- Il reviewer ha avuto ragione: nel body di #4923 avevo scritto che non restavano altre duplicazioni, ma `scripts/send-job-alerts.mjs:486` aveva ancora la propria. Affermazione sbagliata, corretta qui.
- Differisce di proposito: `utm_medium` di default `'email'` (convenzione: medium = canale, source = identificatore) e **preserva** un `utm_medium` già impostato da `utmBase`. Il builder condiviso ora accetta entrambe come opzioni, così i job alert mantengono il comportamento esatto e la definizione dello schema autologin resta una sola.
- Verificato **byte a byte** su 4 forme di URL, inclusa una che porta già `utm_medium`: 4/4 identici.
- Un test di drift ora fallisce se un sender reintroduce una copia privata.

**Lettura Firestore superflua**
- `hasOrWillHaveJobAlert` girava a ogni invio, ma solo il segmento `job` ne usa il risultato: gli altri quattro pagavano un round-trip su subcollection per un valore che nessuno legge. Ora è condizionale, con test che verificano che la lettura avvenga per `job` e **non** per `publisher`.

**`normalizeSector` non era idempotente** (emerso scrivendo i test sopra)
- `health`, `industry`, `education`, `construction`, `transport` tornavano `null` se ricevevano la propria chiave canonica.
- Nessun impatto vivo: quei cinque arrivano in produzione solo come etichette umane (`Sanita / Ospedali`), mai come chiave. Ma il giorno in cui un writer salvasse il valore normalizzato, l'iscritto scenderebbe in silenzio dal segmento `job` a `general` — con la copy sbagliata.
- Le chiavi canoniche ora mappano su sé stesse. Verificato che **tutti e 16 i valori reali di produzione restano invariati** e che uno sconosciuto continua a dare `null`.

## Non implementato (ancora)

Nessuno.

## Test plan

- [x] Suite completa: 139.003 test verdi
- [x] Parità URL job-alert verificata contro l'implementazione precedente: 4/4 identici
- [x] `normalizeSector`: 13/13 chiavi canoniche idempotenti, 16/16 valori reali invariati, sconosciuto → `null`
- [x] Test che la lettura alert avvenga per `job` e non per `publisher`
- [x] Drift test contro la reintroduzione di un builder privato

## Note sugli altri rilievi della review di #4923

- **`backfillJobAlertOnPersonalizationSync` (tier-3)**: il fallback replica solo i tier flat, quindi un iscritto senza segnale flat può ricevere la copy "crea un avviso" anche se un alert nasce poco dopo da quel trigger separato. Lasciato com'è di proposito: coprirlo richiederebbe leggere il subdoc `private/personalization` a ogni invio del segmento job, e l'errore va nella direzione sicura — sotto-promettiamo invece di affermare il falso.
- **Regex di `wrapAuthenticatedHrefs`**: assume href fra virgolette doppie ed escaped. È vero oggi perché ogni call site passa da `escapeHtml()`; un href con un `"` letterale non escaped sarebbe comunque HTML rotto a monte.
